### PR TITLE
Fix agent string

### DIFF
--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -6,6 +6,6 @@ import Ably
 // Version information
 internal let version = "0.1.0"
 
-internal let channelOptionsAgentString = "chat-ios/\(version)"
+internal let channelOptionsAgentString = "chat-swift/\(version)"
 
 internal let defaultChannelParams = ["agent": channelOptionsAgentString]


### PR DESCRIPTION
We don’t have a proper solution for analytics yet (https://github.com/ably/specification/issues/201 is on hold and has been removed from mobile beta scope), but in a conversation in the team we decided that we might as well at least keep the `agent` channel parameter, which will give us information about channel attaches. So, name it in line with the JS SDK, which uses `"chat-js"`; i.e. use the name of the programming language ("ios" is misleading since we might be running on macOS or tvOS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the agent string to reflect the new naming convention for the Swift implementation.

- **Bug Fixes**
	- Ensured consistent usage of the updated agent string across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->