### PR TITLE
Updated to minimum version supporting chat v2.

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1ad2d7338668d15feccbf564582941161acd47349bfca8f34374e11c69677ae8",
+  "originHash" : "1d806168af5c6dfac34494fc5941d89fb9d4f96e4803f3a16742053db45c2b49",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "branch" : "main",
-        "revision" : "5a9b7ba3395ce24a002d552edcb395263fba961d"
+        "revision" : "aca9a7c00abb7eacda8d90dcff75372a60360e7d",
+        "version" : "1.2.35"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b6d25f160b01b473629481d68d4fe734b3981fcd87079531f784c2ade3afdc4d",
+  "originHash" : "87bdf964454a6a566cd3557b1ae36935d1d19b6a8a8073b9fce67464d6593572",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "branch" : "main",
-        "revision" : "5a9b7ba3395ce24a002d552edcb395263fba961d"
+        "revision" : "aca9a7c00abb7eacda8d90dcff75372a60360e7d",
+        "version" : "1.2.35"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            // TODO: Switch back to using a tag (https://github.com/ably-labs/ably-chat-swift/issues/80)
-            branch: "main"
+            from: "1.2.35"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",


### PR DESCRIPTION
Closes https://github.com/ably/ably-chat-swift/issues/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the dependency for `ably-cocoa` to version `1.2.35`, enhancing stability and performance.

- **Bug Fixes**
	- Resolved issues related to dependency management by specifying version requirements instead of branch references.

- **Chores**
	- Updated various package dependencies to their respective versions for improved compatibility:
		- `delta-codec-cocoa` to version `1.3.3`
		- `msgpack-objective-c` to version `0.4.0`
		- `swift-argument-parser` to version `1.5.0`
		- `swift-async-algorithms` to version `1.0.1`
		- `swift-collections` to version `1.1.2`
		- `table` to version `1.1.1`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->