### PR TITLE
[ECO-4915] Add documentation comments

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -178,6 +178,59 @@ jobs:
       - name: Build example app
         run: swift run BuildTool build-example-app --platform ${{ matrix.platform }}
 
+  check-documentation:
+    runs-on: macos-15
+
+    permissions:
+      deployments: write
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # This step can be removed once the runners’ default version of Xcode is 16 or above
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16
+
+      # Dry run upload-action to get base-path url
+      - name: Dry-Run Upload (to get url)
+        id: preupload
+        uses: ably/sdk-upload-action@v2
+        with:
+          mode: preempt
+          sourcePath: .build/plugins/Swift-DocC/outputs/AblyChat.doccarchive # Path to the Swift DocC output folder
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          artifactName: AblyChat
+
+      # Build the documentation using Swift DocC
+      - name: Build documentation
+        run: |
+          swift package generate-documentation --target AblyChat --disable-indexing \
+          --hosting-base-path "${{ steps.preupload.outputs.base-path }}" \
+          --transform-for-static-hosting
+        working-directory: ${{ github.workspace }}
+
+      # Configure AWS credentials for uploading documentation
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-chat-swift
+          role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
+
+      # Upload the generated documentation
+      - name: Upload Documentation
+        uses: ably/sdk-upload-action@v2
+        with:
+          sourcePath: .build/plugins/Swift-DocC/outputs/AblyChat.doccarchive # Path to the Swift DocC output folder
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          artifactName: AblyChat # Optional root-level directory name
+          landingPagePath: documentation/ablychat
+
   # We use this job as a marker that all of the required checks have completed.
   # This allows us to configure a single required status check in our branch
   # protection rules instead of having to type loads of different check names
@@ -193,6 +246,7 @@ jobs:
       - build-and-test-xcode
       - build-release-configuration-xcode
       - check-example-app
+      - check-documentation
 
     steps:
       - name: No-op

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+docs-coverage-report
 # End of .gitignore created by Swift Package Manager
 
 /node_modules

--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1d806168af5c6dfac34494fc5941d89fb9d4f96e4803f3a16742053db45c2b49",
+  "originHash" : "7cf5aad170e2009b8ed30136589be3e449ac79a630487eb65f95143b02db577f",
   "pins" : [
     {
       "identity" : "ably-cocoa",
@@ -53,6 +53,24 @@
       "state" : {
         "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
         "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87bdf964454a6a566cd3557b1ae36935d1d19b6a8a8073b9fce67464d6593572",
+  "originHash" : "f5dd87027f1300f852cf86019686409a47c851bc11433a4138c8956b8a09ad6f",
   "pins" : [
     {
       "identity" : "ably-cocoa",
@@ -53,6 +53,24 @@
       "state" : {
         "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
         "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,10 @@ let package = Package(
             url: "https://github.com/JanGorman/Table.git",
             from: "1.1.1"
         ),
+        .package(
+            url: "https://github.com/apple/swift-docc-plugin",
+            from: "1.0.0"
+        ),
     ],
     targets: [
         .target(

--- a/Sources/AblyChat/BufferingPolicy.swift
+++ b/Sources/AblyChat/BufferingPolicy.swift
@@ -1,5 +1,7 @@
-// Describes what to do with realtime events that come in faster than the consumer of an `AsyncSequence` can handle them.
-// (This is the same as `AsyncStream<T>.Continuation.BufferingPolicy` but with the generic type parameter `T` removed.)
+/**
+ * Describes what to do with realtime events that come in faster than the consumer of an `AsyncSequence` can handle them.
+ * (This is the same as `AsyncStream<T>.Continuation.BufferingPolicy` but with the generic type parameter `T` removed.)
+ */
 public enum BufferingPolicy: Sendable {
     case unbounded
     case bufferingOldest(Int)

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -1,15 +1,48 @@
 import Ably
 
 public protocol ChatClient: AnyObject, Sendable {
+    /**
+     * Returns the rooms object, which provides access to chat rooms.
+     *
+     * - Returns: The rooms object.
+     */
     var rooms: any Rooms { get }
+
+    /**
+     * Returns the underlying connection to Ably, which can be used to monitor the clients
+     * connection to Ably servers.
+     *
+     * - Returns: The connection object.
+     */
     var connection: any Connection { get }
+
+    /**
+     * Returns the clientId of the current client.
+     *
+     * - Returns: The clientId.
+     */
     var clientID: String { get }
+
+    /**
+     * Returns the underlying Ably Realtime client.
+     *
+     * - Returns: The Ably Realtime client.
+     */
     var realtime: RealtimeClient { get }
+
+    /**
+     * Returns the resolved client options for the client, including any defaults that have been set.
+     *
+     * - Returns: The client options.
+     */
     var clientOptions: ClientOptions { get }
 }
 
 public typealias RealtimeClient = any RealtimeClientProtocol
 
+/**
+ * This is the core client for Ably chat. It provides access to chat rooms.
+ */
 public actor DefaultChatClient: ChatClient {
     public let realtime: RealtimeClient
     public nonisolated let clientOptions: ClientOptions
@@ -20,6 +53,13 @@ public actor DefaultChatClient: ChatClient {
     // (CHA-CS4) The chat client must allow its connection status to be observed by clients.
     public nonisolated let connection: any Connection
 
+    /**
+     * Constructor for Chat
+     *
+     * - Parameters:
+     *   - realtime: The Ably Realtime client.
+     *   - clientOptions: The client options.
+     */
     public init(realtime: RealtimeClient, clientOptions: ClientOptions?) {
         self.realtime = realtime
         self.clientOptions = clientOptions ?? .init()
@@ -34,8 +74,22 @@ public actor DefaultChatClient: ChatClient {
     }
 }
 
+/**
+ * Configuration options for the chat client.
+ */
 public struct ClientOptions: Sendable {
+    /**
+     * A custom log handler that will be used to log messages from the client.
+     *
+     * By default, the client will log messages to the console.
+     */
     public var logHandler: LogHandler?
+
+    /**
+     * The minimum log level at which messages will be logged.
+     *
+     * By default, ``LogLevel/error`` will be used.
+     */
     public var logLevel: LogLevel?
 
     public init(logHandler: (any LogHandler)? = nil, logLevel: LogLevel? = nil) {

--- a/Sources/AblyChat/Connection.swift
+++ b/Sources/AblyChat/Connection.swift
@@ -1,11 +1,31 @@
 import Ably
 
+/**
+ * Represents a connection to Ably.
+ */
 public protocol Connection: AnyObject, Sendable {
+    /**
+     * The current status of the connection.
+     */
     var status: ConnectionStatus { get async }
+
     // TODO: (https://github.com/ably-labs/ably-chat-swift/issues/12): consider how to avoid the need for an unwrap
+    /**
+     * The current error, if any, that caused the connection to enter the current status.
+     */
     var error: ARTErrorInfo? { get async }
+
+    /**
+     * Subscribes a given listener to a connection status changes.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``ConnectionStatusChange`` events.
+     */
     func onStatusChange(bufferingPolicy: BufferingPolicy) -> Subscription<ConnectionStatusChange>
-    /// Same as calling ``onStatusChange(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``onStatusChange(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Connection` protocol provides a default implementation of this method.
     func onStatusChange() -> Subscription<ConnectionStatusChange>
@@ -17,18 +37,50 @@ public extension Connection {
     }
 }
 
+/**
+ * The different states that the connection can be in through its lifecycle.
+ */
 public enum ConnectionStatus: Sendable {
     // (CHA-CS1a) The INITIALIZED status is a default status when the realtime client is first initialized. This value will only (likely) be seen if the realtime client doesn’t have autoconnect turned on.
+
+    /**
+     * A temporary state for when the library is first initialized.
+     */
     case initialized
+
     // (CHA-CS1b) The CONNECTING status is used when the client is in the process of connecting to Ably servers.
+
+    /**
+     * The library is currently connecting to Ably.
+     */
     case connecting
+
     // (CHA-CS1c) The CONNECTED status is used when the client connected to Ably servers.
+
+    /**
+     * The library is currently connected to Ably.
+     */
     case connected
+
     // (CHA-CS1d) The DISCONNECTED status is used when the client is not currently connected to Ably servers. This state may be temporary as the underlying Realtime SDK seeks to reconnect.
+
+    /**
+     * The library is currently disconnected from Ably, but will attempt to reconnect.
+     */
     case disconnected
+
     // (CHA-CS1e) The SUSPENDED status is used when the client is in an extended state of disconnection, but will attempt to reconnect.
+
+    /**
+     * The library is in an extended state of disconnection, but will attempt to reconnect.
+     */
     case suspended
+
     // (CHA-CS1f) The FAILED status is used when the client is disconnected from the Ably servers due to some non-retriable failure such as authentication failure. It will not attempt to reconnect.
+
+    /**
+     * The library is currently disconnected from Ably and will not attempt to reconnect.
+     */
     case failed
 
     internal init(from realtimeConnectionState: ARTRealtimeConnectionState) {
@@ -51,11 +103,30 @@ public enum ConnectionStatus: Sendable {
     }
 }
 
+/**
+ * Represents a change in the status of the connection.
+ */
 public struct ConnectionStatusChange: Sendable {
+    /**
+     * The new status of the connection.
+     */
     public var current: ConnectionStatus
+
+    /**
+     * The previous status of the connection.
+     */
     public var previous: ConnectionStatus
+
     // TODO: (https://github.com/ably-labs/ably-chat-swift/issues/12): consider how to avoid the need for an unwrap
+    /**
+     * An error that provides a reason why the connection has
+     * entered the new status, if applicable.
+     */
     public var error: ARTErrorInfo?
+
+    /**
+     * The time in milliseconds that the client will wait before attempting to reconnect.
+     */
     public var retryIn: TimeInterval
 
     public init(current: ConnectionStatus, previous: ConnectionStatus, error: ARTErrorInfo? = nil, retryIn: TimeInterval) {

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -14,7 +14,7 @@ public protocol RealtimeClientProtocol: ARTRealtimeProtocol, Sendable {
     var connection: Connection { get }
 }
 
-/// Expresses the requirements of the object returned by ``RealtimeClientProtocol.channels``.
+/// Expresses the requirements of the object returned by ``RealtimeClientProtocol/channels``.
 public protocol RealtimeChannelsProtocol: ARTRealtimeChannelsProtocol, Sendable {
     associatedtype Channel: RealtimeChannelProtocol
 
@@ -22,7 +22,7 @@ public protocol RealtimeChannelsProtocol: ARTRealtimeChannelsProtocol, Sendable 
     func get(_ name: String, options: ARTRealtimeChannelOptions) -> Channel
 }
 
-/// Expresses the requirements of the object returned by ``RealtimeChannelsProtocol.get(_:)``.
+/// Expresses the requirements of the object returned by ``RealtimeChannelsProtocol/get(_:options:)``.
 public protocol RealtimeChannelProtocol: ARTRealtimeChannelProtocol, Sendable {}
 
 public protocol ConnectionProtocol: ARTConnectionProtocol, Sendable {}

--- a/Sources/AblyChat/EmitsDiscontinuities.swift
+++ b/Sources/AblyChat/EmitsDiscontinuities.swift
@@ -9,9 +9,21 @@ public struct DiscontinuityEvent: Sendable, Equatable {
     }
 }
 
+/**
+ * An interface to be implemented by objects that can emit discontinuities to listeners.
+ */
 public protocol EmitsDiscontinuities {
+    /**
+     * Subscribes a given listener to a detected discontinuity.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``DiscontinuityEvent`` events.
+     */
     func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent>
-    /// Same as calling ``onDiscontinuity(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``onDiscontinuity(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `EmitsDiscontinuities` protocol provides a default implementation of this method.
     func onDiscontinuity() async -> Subscription<DiscontinuityEvent>

--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -1,9 +1,9 @@
 import Ably
 
 /**
- The error domain used for the ``Ably.ARTErrorInfo`` error instances thrown by the Ably Chat SDK.
+ The error domain used for the `ARTErrorInfo` error instances thrown by the Ably Chat SDK.
 
- See ``ErrorCode`` for the possible ``ARTErrorInfo.code`` values.
+ See ``ErrorCode`` for the possible `code` values.
  */
 public let errorDomain = "AblyChatErrorDomain"
 
@@ -14,22 +14,74 @@ public enum ErrorCode: Int {
     /// The user attempted to perform an invalid action.
     case badRequest = 40000
 
+    /**
+     * The messages feature failed to attach.
+     */
     case messagesAttachmentFailed = 102_001
+
+    /**
+     * The presence feature failed to attach.
+     */
     case presenceAttachmentFailed = 102_002
+
+    /**
+     * The reactions feature failed to attach.
+     */
     case reactionsAttachmentFailed = 102_003
+
+    /**
+     * The occupancy feature failed to attach.
+     */
     case occupancyAttachmentFailed = 102_004
+
+    /**
+     * The typing feature failed to attach.
+     */
     case typingAttachmentFailed = 102_005
 
+    /**
+     * The messages feature failed to detach.
+     */
     case messagesDetachmentFailed = 102_050
+
+    /**
+     * The presence feature failed to detach.
+     */
     case presenceDetachmentFailed = 102_051
+
+    /**
+     * The reactions feature failed to detach.
+     */
     case reactionsDetachmentFailed = 102_052
+
+    /**
+     * The occupancy feature failed to detach.
+     */
     case occupancyDetachmentFailed = 102_053
+
+    /**
+     * The typing feature failed to detach.
+     */
     case typingDetachmentFailed = 102_054
 
+    /**
+     * Cannot perform operation because the room is in a failed state.
+     */
     case roomInFailedState = 102_101
+
+    /**
+     * Cannot perform operation because the room is in a releasing state.
+     */
     case roomIsReleasing = 102_102
+
+    /**
+     * Cannot perform operation because the room is in a released state.
+     */
     case roomIsReleased = 102_103
 
+    /**
+     * Room was released before the operation could complete.
+     */
     case roomReleasedBeforeOperationCompleted = 102_106
 
     case roomInInvalidState = 102_107
@@ -87,7 +139,7 @@ public enum ErrorCode: Int {
             }
         }
 
-        /// The ``ARTErrorInfo.statusCode`` that should be returned for this error.
+        /// The ``ARTErrorInfo/statusCode`` that should be returned for this error.
         internal var statusCode: Int {
             // These status codes are taken from the "Chat-specific Error Codes" section of the spec.
             switch self {
@@ -133,7 +185,7 @@ internal enum ErrorCodeAndStatusCode {
     case fixedStatusCode(ErrorCode.CaseThatImpliesFixedStatusCode)
     case variableStatusCode(ErrorCode.CaseThatImpliesVariableStatusCode, statusCode: Int)
 
-    /// The ``ARTErrorInfo.code`` that should be returned for this error.
+    /// The ``ARTErrorInfo/code`` that should be returned for this error.
     internal var code: ErrorCode {
         switch self {
         case let .fixedStatusCode(code):
@@ -143,7 +195,7 @@ internal enum ErrorCodeAndStatusCode {
         }
     }
 
-    /// The ``ARTErrorInfo.statusCode`` that should be returned for this error.
+    /// The ``ARTErrorInfo/statusCode`` that should be returned for this error.
     internal var statusCode: Int {
         switch self {
         case let .fixedStatusCode(code):
@@ -252,7 +304,7 @@ internal enum ChatError {
         return "The \(descriptionOfFeature(feature)) feature failed to \(operationDescription)."
     }
 
-    /// The ``ARTErrorInfo.localizedDescription`` that should be returned for this error.
+    /// The ``ARTErrorInfo/localizedDescription`` that should be returned for this error.
     internal var localizedDescription: String {
         switch self {
         case let .inconsistentRoomOptions(requested, existing):
@@ -276,7 +328,7 @@ internal enum ChatError {
         }
     }
 
-    /// The ``ARTErrorInfo.cause`` that should be returned for this error.
+    /// The ``ARTErrorInfo/cause`` that should be returned for this error.
     internal var cause: ARTErrorInfo? {
         switch self {
         case let .attachmentFailed(_, underlyingError):

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -1,6 +1,12 @@
 import Ably
 
+/**
+ * Chat Message Actions.
+ */
 public enum MessageAction: String, Codable, Sendable {
+    /**
+     * Action applied to a new message.
+     */
     case create = "message.create"
 
     internal static func fromRealtimeAction(_ action: ARTMessageAction) -> Self? {
@@ -21,7 +27,9 @@ public enum MessageAction: String, Codable, Sendable {
     }
 }
 
+/// Realtime chat message names.
 internal enum RealtimeMessageName: String, Sendable {
+    /// Represents a regular chat message.
     case chatMessage = "chat.message"
 }
 

--- a/Sources/AblyChat/Headers.swift
+++ b/Sources/AblyChat/Headers.swift
@@ -46,4 +46,19 @@ extension HeadersValue: JSONEncodable {
 // The corresponding type in TypeScript is
 // Record<string, number | string | boolean | null | undefined>
 // There may be a better way to represent it in Swift; this will do for now. Have omitted `undefined` because I don’t know how that would occur.
+
+/**
+ * Headers are a flat key-value map that can be attached to chat messages.
+ *
+ * The headers are a flat key-value map and are sent as part of the realtime
+ * message's extras inside the `headers` property. They can serve similar
+ * purposes as ``Metadata`` but as opposed to `Metadata` they are read by Ably and
+ * can be used for features such as
+ * [subscription filters](https://faqs.ably.com/subscription-filters).
+ *
+ * Do not use the headers for authoritative information. There is no
+ * server-side validation. When reading the headers treat them like user
+ * input.
+ *
+ */
 public typealias Headers = [String: HeadersValue]

--- a/Sources/AblyChat/Logging.swift
+++ b/Sources/AblyChat/Logging.swift
@@ -3,9 +3,20 @@ import os
 public typealias LogContext = [String: any Sendable]
 
 public protocol LogHandler: AnyObject, Sendable {
+    /**
+     * A function that can be used to handle log messages.
+     *
+     * - Parameters:
+     *   - message: The message to log.
+     *   - level: The log level of the message.
+     *   - context: The context of the log message as key-value pairs.
+     */
     func log(message: String, level: LogLevel, context: LogContext?)
 }
 
+/**
+ * Represents the different levels of logging that can be used.
+ */
 public enum LogLevel: Sendable, Comparable {
     case trace
     case debug

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -1,20 +1,80 @@
 import Foundation
 
+/**
+ * ``Headers`` type for chat messages.
+ */
 public typealias MessageHeaders = Headers
+
+/**
+ * ``Metadata`` type for chat messages.
+ */
 public typealias MessageMetadata = Metadata
 
-// (CHA-M2) A Message corresponds to a single message in a chat room. This is analogous to a single user-specified message on an Ably channel (NOTE: not a ProtocolMessage).
+/**
+ * Represents a single message in a chat room.
+ */
 public struct Message: Sendable, Codable, Identifiable, Equatable {
     // id to meet Identifiable conformance. 2 messages in the same channel cannot have the same serial.
     public var id: String { serial }
 
+    /**
+     * The unique identifier of the message.
+     */
     public var serial: String
+
+    /**
+     * The action type of the message. This can be used to determine if the message was created, updated, or deleted.
+     */
     public var action: MessageAction
+
+    /**
+     * The clientId of the user who created the message.
+     */
+
     public var clientID: String
+
+    /**
+     * The roomId of the chat room to which the message belongs.
+     */
     public var roomID: String
+
+    /**
+     * The text of the message.
+     */
     public var text: String
+
+    /**
+     * The timestamp at which the message was created.
+     */
     public var createdAt: Date?
+
+    /**
+     * The metadata of a chat message. Allows for attaching extra info to a message,
+     * which can be used for various features such as animations, effects, or simply
+     * to link it to other resources such as images, relative points in time, etc.
+     *
+     * Metadata is part of the Ably Pub/sub message content and is not read by Ably.
+     *
+     * This value is always set. If there is no metadata, this is an empty object.
+     *
+     * Do not use metadata for authoritative information. There is no server-side
+     * validation. When reading the metadata treat it like user input.
+     */
     public var metadata: MessageMetadata
+
+    /**
+     * The headers of a chat message. Headers enable attaching extra info to a message,
+     * which can be used for various features such as linking to a relative point in
+     * time of a livestream video or flagging this message as important or pinned.
+     *
+     * Headers are part of the Ably realtime message extras.headers and they can be used
+     * for [Filtered Subscriptions](https://faqs.ably.com/subscription-filters) and similar.
+     *
+     * This value is always set. If there are no headers, this is an empty object.
+     *
+     * Do not use the headers for authoritative information. There is no server-side
+     * validation. When reading the headers treat them like user input.
+     */
     public var headers: MessageHeaders
 
     public init(serial: String, action: MessageAction, clientID: String, roomID: String, text: String, createdAt: Date?, metadata: MessageMetadata, headers: MessageHeaders) {

--- a/Sources/AblyChat/Metadata.swift
+++ b/Sources/AblyChat/Metadata.swift
@@ -8,6 +8,16 @@ public enum MetadataValue: Sendable, Codable, Equatable {
     case null
 }
 
+/**
+ * Metadata is a map of extra information that can be attached to chat
+ * messages. It is not used by Ably and is sent as part of the realtime
+ * message payload. Example use cases are setting custom styling like
+ * background or text colors or fonts, adding links to external images,
+ * emojis, etc.
+ *
+ * Do not use metadata for authoritative information. There is no server-side
+ * validation. When reading the metadata treat it like user input.
+ */
 public typealias Metadata = [String: MetadataValue]
 
 extension MetadataValue: JSONDecodable {

--- a/Sources/AblyChat/Occupancy.swift
+++ b/Sources/AblyChat/Occupancy.swift
@@ -1,12 +1,39 @@
 import Ably
 
+/**
+ * This interface is used to interact with occupancy in a chat room: subscribing to occupancy updates and
+ * fetching the current room occupancy metrics.
+ *
+ * Get an instance via ``Room/occupancy``.
+ */
 public protocol Occupancy: AnyObject, Sendable, EmitsDiscontinuities {
+    /**
+     * Subscribes a given listener to occupancy updates of the chat room.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``OccupancyEvent`` events.
+     */
     func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<OccupancyEvent>
-    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Occupancy` protocol provides a default implementation of this method.
     func subscribe() async -> Subscription<OccupancyEvent>
+
+    /**
+     * Get the current occupancy of the chat room.
+     *
+     * - Returns: A current occupancy of the chat room.
+     */
     func get() async throws -> OccupancyEvent
+
+    /**
+     * Get underlying Ably channel for occupancy events.
+     *
+     * - Returns: The underlying Ably channel for occupancy events.
+     */
     var channel: RealtimeChannelProtocol { get }
 }
 
@@ -17,8 +44,19 @@ public extension Occupancy {
 }
 
 // (CHA-O2) The occupancy event format is shown here (https://sdk.ably.com/builds/ably/specification/main/chat-features/#chat-structs-occupancy-event)
+
+/**
+ * Represents the occupancy of a chat room.
+ */
 public struct OccupancyEvent: Sendable, Encodable, Decodable {
+    /**
+     * The number of connections to the chat room.
+     */
     public var connections: Int
+
+    /**
+     * The number of presence members in the chat room - members who have entered presence.
+     */
     public var presenceMembers: Int
 
     public init(connections: Int, presenceMembers: Int) {

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -2,23 +2,124 @@ import Ably
 
 public typealias PresenceData = JSONValue
 
+/**
+ * This interface is used to interact with presence in a chat room: subscribing to presence events,
+ * fetching presence members, or sending presence events (`enter`, `update`, `leave`).
+ *
+ * Get an instance via ``Room/presence``.
+ */
 public protocol Presence: AnyObject, Sendable, EmitsDiscontinuities {
+    /**
+     * Same as ``get(params:)``, but with defaults params.
+     */
     func get() async throws -> [PresenceMember]
+
+    /**
+     * Method to get list of the current online users and returns the latest presence messages associated to it.
+     *
+     * - Parameters:
+     *   - params: ``PresenceQuery`` that control how the presence set is retrieved.
+     *
+     * - Returns: An array of ``PresenceMember``s.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func get(params: PresenceQuery) async throws -> [PresenceMember]
+
+    /**
+     * Method to check if user with supplied clientId is online.
+     *
+     * - Parameters:
+     *   - clientID: The client ID to check if it is present in the room.
+     *
+     * - Returns: A boolean value indicating whether the user is present in the room.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func isUserPresent(clientID: String) async throws -> Bool
+
+    /**
+     * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.
+     *
+     * - Parameters:
+     *   - data: The users data, a JSON serializable object that will be sent to all subscribers.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func enter(data: PresenceData) async throws
-    func enter() async throws
+
+    /**
+     * Method to update room presence, will emit an update event to all subscribers. If the user is not present, it will be treated as a join event.
+     *
+     * - Parameters:
+     *   - data: The users data, a JSON serializable object that will be sent to all subscribers.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func update(data: PresenceData) async throws
-    func update() async throws
+
+    /**
+     * Method to leave room presence, will emit a leave event to all subscribers. If the user is not present, it will be treated as a no-op.
+     *
+     * - Parameters:
+     *   - data: The users data, a JSON serializable object that will be sent to all subscribers.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func leave(data: PresenceData) async throws
-    func leave() async throws
+
+    /**
+     * Subscribes a given listener to a particular presence event in the chat room.
+     *
+     * - Parameters:
+     *   - event: A single presence event type ``PresenceEventType`` to subscribe to.
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``PresenceEvent`` events.
+     */
     func subscribe(event: PresenceEventType, bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
-    /// Same as calling ``subscribe(event:bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /**
+     * Subscribes a given listener to different presence events in the chat room.
+     *
+     * - Parameters:
+     *   - events: An array of presence event types ``PresenceEventType`` to subscribe to.
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``PresenceEvent`` events.
+     */
+    func subscribe(events: [PresenceEventType], bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
+
+    /**
+     * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.
+     * In oppose to ``enter(data:)`` it doesn't publish any custom presence data.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
+    func enter() async throws
+
+    /**
+     * Method to update room presence, will emit an update event to all subscribers. If the user is not present, it will be treated as a join event.
+     * In oppose to ``update(data:)`` it doesn't publish any custom presence data.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
+    func update() async throws
+
+    /**
+     * Method to leave room presence, will emit a leave event to all subscribers. If the user is not present, it will be treated as a no-op.
+     * In oppose to ``leave(data:)`` it doesn't publish any custom presence data.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
+    func leave() async throws
+
+    /// Same as calling ``subscribe(event:bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Presence` protocol provides a default implementation of this method.
     func subscribe(event: PresenceEventType) async -> Subscription<PresenceEvent>
-    func subscribe(events: [PresenceEventType], bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
-    /// Same as calling ``subscribe(events:bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``subscribe(events:bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Presence` protocol provides a default implementation of this method.
     func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent>
@@ -34,6 +135,9 @@ public extension Presence {
     }
 }
 
+/**
+ * Type for PresenceMember
+ */
 public struct PresenceMember: Sendable {
     public enum Action: Sendable {
         case present
@@ -70,19 +174,53 @@ public struct PresenceMember: Sendable {
         self.updatedAt = updatedAt
     }
 
+    /**
+     * The clientId of the presence member.
+     */
     public var clientID: String
-    // `nil` means that there is no presence data; this is different to a `JSONValue` of case `.null`
+
+    /**
+     * The data associated with the presence member.
+     * `nil` means that there is no presence data; this is different to a `JSONValue` of case `.null`
+     */
     public var data: PresenceData?
+
+    /**
+     * The current state of the presence member.
+     */
     public var action: Action
+
     // TODO: (https://github.com/ably-labs/ably-chat-swift/issues/13): try to improve this type
+
+    /**
+     * The extras associated with the presence member.
+     */
     public var extras: (any Sendable)?
     public var updatedAt: Date
 }
 
+/**
+ * Enum representing presence events.
+ */
 public enum PresenceEventType: Sendable {
+    /**
+     * Event triggered when a user enters.
+     */
     case enter
+
+    /**
+     * Event triggered when a user leaves.
+     */
     case leave
+
+    /**
+     * Event triggered when a user updates their presence data.
+     */
     case update
+
+    /**
+     * Event triggered when a user initially subscribes to presence.
+     */
     case present
 
     internal func toARTPresenceAction() -> ARTPresenceAction {
@@ -99,10 +237,28 @@ public enum PresenceEventType: Sendable {
     }
 }
 
+/**
+ * Type for PresenceEvent
+ */
 public struct PresenceEvent: Sendable {
+    /**
+     * The type of the presence event.
+     */
     public var action: PresenceEventType
+
+    /**
+     * The clientId of the client that triggered the presence event.
+     */
     public var clientID: String
+
+    /**
+     * The timestamp of the presence event.
+     */
     public var timestamp: Date
+
+    /**
+     * The data associated with the presence event.
+     */
     public var data: PresenceData?
 
     public init(action: PresenceEventType, clientID: String, timestamp: Date, data: PresenceData?) {
@@ -115,7 +271,7 @@ public struct PresenceEvent: Sendable {
 
 // This is a Sendable equivalent of ably-cocoa’s ARTRealtimePresenceQuery type.
 //
-// Originally, ``Presence.get(params:)`` accepted an ARTRealtimePresenceQuery object, but I’ve changed it to accept this type, because else when you try and write an actor that implements ``Presence``, you get a compiler error like "Non-sendable type 'ARTRealtimePresenceQuery' in parameter of the protocol requirement satisfied by actor-isolated instance method 'get(params:)' cannot cross actor boundary; this is an error in the Swift 6 language mode".
+// Originally, ``Presence/get(params:)`` accepted an ARTRealtimePresenceQuery object, but I’ve changed it to accept this type, because else when you try and write an actor that implements ``Presence``, you get a compiler error like "Non-sendable type 'ARTRealtimePresenceQuery' in parameter of the protocol requirement satisfied by actor-isolated instance method 'get(params:)' cannot cross actor boundary; this is an error in the Swift 6 language mode".
 //
 // Now, based on my limited understanding, you _should_ be able to send non-Sendable values from one isolation domain to another (the purpose of the "region-based isolation" and "`sending` parameters" features added in Swift 6), but to get this to work I had to mark ``Presence`` as requiring conformance to the `Actor` protocol, and since I didn’t understand _why_ I had to do that, I didn’t want to put it in the public API.
 //

--- a/Sources/AblyChat/Reaction.swift
+++ b/Sources/AblyChat/Reaction.swift
@@ -1,15 +1,49 @@
 import Foundation
 
+/**
+ * ``Headers`` type for chat reactions.
+ */
 public typealias ReactionHeaders = Headers
+
+/**
+ * ``Metadata`` type for chat reactions.
+ */
 public typealias ReactionMetadata = Metadata
 
 // (CHA-ER2) A Reaction corresponds to a single reaction in a chat room. This is analogous to a single user-specified message on an Ably channel (NOTE: not a ProtocolMessage).
+
+/**
+ * Represents a room-level reaction.
+ */
 public struct Reaction: Sendable {
+    /**
+     * The type of the reaction, for example "like" or "love".
+     */
     public var type: String
+
+    /**
+     * Metadata of the reaction. If no metadata was set this is an empty object.
+     */
     public var metadata: ReactionMetadata
+
+    /**
+     * Headers of the reaction. If no headers were set this is an empty object.
+     */
     public var headers: ReactionHeaders
+
+    /**
+     * The timestamp at which the reaction was sent.
+     */
     public var createdAt: Date
+
+    /**
+     * The clientId of the user who sent the reaction.
+     */
     public var clientID: String
+
+    /**
+     * Whether the reaction was sent by the current user.
+     */
     public var isSelf: Bool
 
     public init(type: String, metadata: ReactionMetadata, headers: ReactionHeaders, createdAt: Date, clientID: String, isSelf: Bool) {

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -1,25 +1,107 @@
 import Ably
 
+/**
+ * Represents a chat room.
+ */
 public protocol Room: AnyObject, Sendable {
+    /**
+     * The unique identifier of the room.
+     *
+     * - Returns: The room identifier.
+     */
     var roomID: String { get }
+
+    /**
+     * Allows you to send, subscribe-to and query messages in the room.
+     *
+     * - Returns: The messages instance for the room.
+     */
     var messages: any Messages { get }
-    // To access this property if presence is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+
+    /**
+     * Allows you to subscribe to presence events in the room.
+     *
+     * - Note: To access this property if presence is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+     *
+     * - Returns: The presence instance for the room.
+     */
     var presence: any Presence { get }
-    // To access this property if reactions are not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+
+    /**
+     * Allows you to interact with room-level reactions.
+     *
+     * - Note: To access this property if presence is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+     *
+     * - Returns: The room reactions instance for the room.
+     */
     var reactions: any RoomReactions { get }
-    // To access this property if typing is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+
+    /**
+     * Allows you to interact with typing events in the room.
+     *
+     * - Note: To access this property if presence is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+     *
+     * - Returns: The typing instance for the room.
+     */
     var typing: any Typing { get }
-    // To access this property if occupancy is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+
+    /**
+     * Allows you to interact with occupancy metrics for the room.
+     *
+     * - Note: To access this property if presence is not enabled for the room is a programmer error, and will lead to `fatalError` being called.
+     *
+     * - Returns: The occupancy instance for the room.
+     */
     var occupancy: any Occupancy { get }
-    // TODO: change to `status`
+
+    /**
+     * The current status of the room.
+     *
+     * - Returns: The current room status.
+     */
     var status: RoomStatus { get async }
+
+    /**
+     * Subscribes a given listener to the room status changes.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``RoomStatusChange`` events.
+     */
     func onStatusChange(bufferingPolicy: BufferingPolicy) async -> Subscription<RoomStatusChange>
-    /// Same as calling ``onStatusChange(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``onStatusChange(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Room` protocol provides a default implementation of this method.
     func onStatusChange() async -> Subscription<RoomStatusChange>
+
+    /**
+     * Attaches to the room to receive events in realtime.
+     *
+     * If a room fails to attach, it will enter either the ``RoomStatus/suspended(error:)`` or ``RoomStatus/failed(error:)`` state.
+     *
+     * If the room enters the failed state, then it will not automatically retry attaching and intervention is required.
+     *
+     * If the room enters the suspended state, then the call to attach will throw `ARTErrorInfo` with the cause of the suspension. However,
+     * the room will automatically retry attaching after a delay.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func attach() async throws
+
+    /**
+     * Detaches from the room to stop receiving events in realtime.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func detach() async throws
+
+    /**
+     * Returns the room options.
+     *
+     * - Returns: A copy of the options used to create the room.
+     */
     var options: RoomOptions { get }
 }
 
@@ -34,8 +116,18 @@ internal protocol InternalRoom: Room {
     func release() async
 }
 
+/**
+ * Represents a change in the status of the room.
+ */
 public struct RoomStatusChange: Sendable, Equatable {
+    /**
+     * The new status of the room.
+     */
     public var current: RoomStatus
+
+    /**
+     * The previous status of the room.
+     */
     public var previous: RoomStatus
 
     public init(current: RoomStatus, previous: RoomStatus) {

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -52,9 +52,9 @@ internal protocol FeatureChannel: Sendable, EmitsDiscontinuities {
     ///
     /// Implements the checks described by CHA-PR3d, CHA-PR3e, and CHA-PR3h (and similar ones described by other functionality that performs contributor presence operations). Namely:
     ///
-    /// - CHA-RL9, which is invoked by CHA-PR3d, CHA-PR10d, CHA-PR6c, CHA-T2c: If the room is in the ATTACHING status, it waits for the next room status change. If the new status is ATTACHED, it returns. Else, it throws an `ARTErrorInfo` derived from ``ChatError.roomTransitionedToInvalidStateForPresenceOperation(cause:)``.
+    /// - CHA-RL9, which is invoked by CHA-PR3d, CHA-PR10d, CHA-PR6c, CHA-T2c: If the room is in the ATTACHING status, it waits for the next room status change. If the new status is ATTACHED, it returns. Else, it throws an `ARTErrorInfo` derived from ``ChatError/roomTransitionedToInvalidStateForPresenceOperation(cause:)``.
     /// - CHA-PR3e, CHA-PR10e, CHA-PR6d, CHA-T2d: If the room is in the ATTACHED status, it returns immediately.
-    /// - CHA-PR3h, CHA-PR10h, CHA-PR6h, CHA-T2g: If the room is in any other status, it throws an `ARTErrorInfo` derived from ``ChatError.presenceOperationRequiresRoomAttach(feature:)``.
+    /// - CHA-PR3h, CHA-PR10h, CHA-PR6h, CHA-T2g: If the room is in any other status, it throws an `ARTErrorInfo` derived from ``ChatError/presenceOperationRequiresRoomAttach(feature:)``.
     ///
     /// - Parameters:
     ///   - requester: The room feature that wishes to perform a presence operation. This is only used for customising the message of the thrown error.

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -18,7 +18,7 @@ internal protocol RoomLifecycleContributorChannel: Sendable {
     var state: ARTRealtimeChannelState { get async }
     var errorReason: ARTErrorInfo? { get async }
 
-    /// Equivalent to subscribing to a `RealtimeChannelProtocol` object’s state changes via its `on(_:)` method. The subscription should use the ``BufferingPolicy.unbounded`` buffering policy.
+    /// Equivalent to subscribing to a `RealtimeChannelProtocol` object’s state changes via its `on(_:)` method. The subscription should use the ``BufferingPolicy/unbounded`` buffering policy.
     ///
     /// It is marked as `async` purely to make it easier to write mocks for this method (i.e. to use an actor as a mock).
     func subscribeToState() async -> Subscription<ARTChannelStateChange>
@@ -84,7 +84,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
     // MARK: - Variable properties
 
     private var status: Status
-    /// Manager state that relates to individual contributors, keyed by contributors’ ``Contributor.id``. Stored separately from ``contributors`` so that the latter can be a `let`, to make it clear that the contributors remain fixed for the lifetime of the manager.
+    /// Manager state that relates to individual contributors, keyed by contributors’ ``Contributor/id``. Stored separately from ``contributors`` so that the latter can be a `let`, to make it clear that the contributors remain fixed for the lifetime of the manager.
     private var contributorAnnotations: ContributorAnnotations
     private var listenForStateChangesTask: Task<Void, Never>!
     // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
@@ -397,7 +397,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
         /// - (if the state change is ATTACHED) the manager has recorded that an ATTACHED state change has been observed for the contributor
         /// - the manager has recorded all pending discontinuity events provoked by the state change (you can retrieve these using ``testsOnly_pendingDiscontinuityEvent(for:)``)
         /// - the manager has performed all status changes provoked by the state change (this does _not_ include the case in which the state change provokes the creation of a transient disconnect timeout which subsequently provokes a status change; use ``testsOnly_subscribeToHandledTransientDisconnectTimeouts()`` to find out about those)
-        /// - the manager has performed all contributor actions provoked by the state change, namely calls to ``RoomLifecycleContributorChannel.detach()`` or ``RoomLifecycleContributor.emitDiscontinuity(_:)``
+        /// - the manager has performed all contributor actions provoked by the state change, namely calls to ``RoomLifecycleContributorChannel/detach()`` or ``RoomLifecycleContributor/emitDiscontinuity(_:)``
         /// - the manager has recorded all transient disconnect timeouts provoked by the state change (you can retrieve this information using ``testsOnly_hasTransientDisconnectTimeout(for:) or ``testsOnly_idOfTransientDisconnectTimeout(for:)``)
         /// - the manager has performed all transient disconnect timeout cancellations provoked by the state change (you can retrieve this information using ``testsOnly_hasTransientDisconnectTimeout(for:) or ``testsOnly_idOfTransientDisconnectTimeout(for:)``)
         internal func testsOnly_subscribeToHandledContributorStateChanges() -> Subscription<ARTChannelStateChange> {

--- a/Sources/AblyChat/RoomOptions.swift
+++ b/Sources/AblyChat/RoomOptions.swift
@@ -1,9 +1,31 @@
 import Foundation
 
+/**
+ * Represents the options for a given chat room.
+ */
 public struct RoomOptions: Sendable, Equatable {
+    /**
+     * The presence options for the room. To enable presence in the room, set this property.
+     * Alternatively, you may use ``RoomOptions/allFeaturesEnabled`` to enable presence with the default options.
+     */
     public var presence: PresenceOptions?
+
+    /**
+     * The typing options for the room. To enable typing in the room, set this property.
+     * Alternatively, you may use ``RoomOptions/allFeaturesEnabled`` to enable typing with the default options.
+     */
     public var typing: TypingOptions?
+
+    /**
+     * The reactions options for the room. To enable reactions in the room, set this property.
+     * Alternatively, you may use ``RoomOptions/allFeaturesEnabled`` to enable reactions with the default options.
+     */
     public var reactions: RoomReactionsOptions?
+
+    /**
+     * The occupancy options for the room. To enable occupancy in the room, set this property.
+     * Alternatively, you may use ``RoomOptions/allFeaturesEnabled`` to enable occupancy with the default options.
+     */
     public var occupancy: OccupancyOptions?
 
     /// A `RoomOptions` which enables all room features, using the default settings for each feature.
@@ -25,8 +47,25 @@ public struct RoomOptions: Sendable, Equatable {
 // (CHA-PR9) Users may configure their presence options via the RoomOptions provided at room configuration time.
 // (CHA-PR9a) Setting enter to false prevents the user from entering presence by means of the ChannelMode on the underlying realtime channel. Entering presence will result in an error. The default is true.
 // (CHA-PR9b) Setting subscribe to false prevents the user from subscribing to presence by means of the ChannelMode on the underlying realtime channel. This does not prevent them from receiving their own presence messages, but they will not receive them from others. The default is true.
+
+/**
+ * Represents the presence options for a chat room.
+ */
 public struct PresenceOptions: Sendable, Equatable {
+    /**
+     * Whether the underlying Realtime channel should use the presence enter mode, allowing entry into presence.
+     * This property does not affect the presence lifecycle, and users must still call ``Presence/enter()``
+     * in order to enter presence.
+     * Defaults to true.
+     */
     public var enter = true
+
+    /**
+     * Whether the underlying Realtime channel should use the presence subscribe mode, allowing subscription to presence.
+     * This property does not affect the presence lifecycle, and users must still call ``Presence/subscribe(events:)``
+     * in order to subscribe to presence.
+     * Defaults to true.
+     */
     public var subscribe = true
 
     public init(enter: Bool = true, subscribe: Bool = true) {
@@ -36,7 +75,16 @@ public struct PresenceOptions: Sendable, Equatable {
 }
 
 // (CHA-T3) Users may configure a timeout interval for when they are typing. This configuration is provided as part of the RoomOptions typing.timeoutMs property, or idiomatic equivalent. The default is 5000ms.
+
+/**
+ * Represents the typing options for a chat room.
+ */
 public struct TypingOptions: Sendable, Equatable {
+    /**
+     * The timeout for typing events in seconds. If ``Typing/start()`` is not called for this amount of time, a stop
+     * typing event will be fired, resulting in the user being removed from the currently typing set.
+     * Defaults to 5 seconds.
+     */
     public var timeout: TimeInterval = 5
 
     public init(timeout: TimeInterval = 5) {
@@ -44,10 +92,16 @@ public struct TypingOptions: Sendable, Equatable {
     }
 }
 
+/**
+ * Represents the reactions options for a chat room.
+ */
 public struct RoomReactionsOptions: Sendable, Equatable {
     public init() {}
 }
 
+/**
+ * Represents the occupancy options for a chat room.
+ */
 public struct OccupancyOptions: Sendable, Equatable {
     public init() {}
 }

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -1,10 +1,40 @@
 import Ably
 
+/**
+ * This interface is used to interact with room-level reactions in a chat room: subscribing to reactions and sending them.
+ *
+ * Get an instance via ``Room/reactions``.
+ */
 public protocol RoomReactions: AnyObject, Sendable, EmitsDiscontinuities {
+    /**
+     * Send a reaction to the room including some metadata.
+     *
+     * - Parameters:
+     *   - params: An object containing `type` and optional `headers` with `metadata`.
+     *
+     * - Note: It is possible to receive your own reaction via the reactions subscription before this method returns.
+     */
     func send(params: SendReactionParams) async throws
+
+    /**
+     * Returns an instance of the Ably realtime channel used for room-level reactions.
+     * Avoid using this directly unless special features that cannot otherwise be implemented are needed.
+     *
+     * - Returns: The realtime channel.
+     */
     var channel: RealtimeChannelProtocol { get }
+
+    /**
+     * Subscribes a given listener to receive room-level reactions.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``Reaction`` events.
+     */
     func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<Reaction>
-    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `RoomReactions` protocol provides a default implementation of this method.
     func subscribe() async -> Subscription<Reaction>
@@ -16,9 +46,41 @@ public extension RoomReactions {
     }
 }
 
+/**
+ * Params for sending a room-level reactions. Only `type` is mandatory.
+ */
 public struct SendReactionParams: Sendable {
+    /**
+     * The type of the reaction, for example an emoji or a short string such as "like".
+     * It is the only mandatory parameter to send a room-level reaction.
+     */
     public var type: String
+
+    /**
+     * Optional metadata of the reaction.
+     *
+     * The metadata is a map of extra information that can be attached to the
+     * room reaction. It is not used by Ably and is sent as part of the realtime
+     * message payload. Example use cases are custom animations or other effects.
+     *
+     * Do not use metadata for authoritative information. There is no server-side
+     * validation. When reading the metadata treat it like user input.
+     */
     public var metadata: ReactionMetadata?
+
+    /**
+     * Optional headers of the room reaction.
+     *
+     * The headers are a flat key-value map and are sent as part of the realtime
+     * message's `extras` inside the `headers` property. They can serve similar
+     * purposes as the metadata but they are read by Ably and can be used for
+     * features such as
+     * [subscription filters](https://faqs.ably.com/subscription-filters).
+     *
+     * Do not use the headers for authoritative information. There is no
+     * server-side validation. When reading the headers treat them like user
+     * input.
+     */
     public var headers: ReactionHeaders?
 
     public init(type: String, metadata: ReactionMetadata? = nil, headers: ReactionHeaders? = nil) {

--- a/Sources/AblyChat/RoomStatus.swift
+++ b/Sources/AblyChat/RoomStatus.swift
@@ -1,15 +1,52 @@
 import Ably
 
-// TODO: rename
+/**
+ * The different states that a room can be in throughout its lifecycle.
+ */
 public enum RoomStatus: Sendable, Equatable {
+    /**
+     * A temporary state for when the room object is first initialized.
+     */
     case initialized
+
+    /**
+     * The library is currently attempting to attach the room.
+     */
     case attaching(error: ARTErrorInfo?)
+
+    /**
+     * The room is currently attached and receiving events.
+     */
     case attached
+
+    /**
+     * The room is currently detaching and will not receive events.
+     */
     case detaching
+
+    /**
+     * The room is currently detached and will not receive events.
+     */
     case detached
+
+    /**
+     * The room is in an extended state of detachment, but will attempt to re-attach when able.
+     */
     case suspended(error: ARTErrorInfo)
+
+    /**
+     * The room is currently detached and will not attempt to re-attach. User intervention is required.
+     */
     case failed(error: ARTErrorInfo)
+
+    /**
+     * The room is in the process of releasing. Attempting to use a room in this state may result in undefined behavior.
+     */
     case releasing
+
+    /**
+     * The room has been released and is no longer usable.
+     */
     case released
 
     internal var error: ARTErrorInfo? {

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -1,8 +1,52 @@
 import Ably
 
+/**
+ * Manages the lifecycle of chat rooms.
+ */
 public protocol Rooms: AnyObject, Sendable {
+    /**
+     * Gets a room reference by ID. The Rooms class ensures that only one reference
+     * exists for each room. A new reference object is created if it doesn't already
+     * exist, or if the one used previously was released using ``release(roomID:)``.
+     *
+     * Always call `release(roomID:)` after the ``Room`` object is no longer needed.
+     *
+     * If a call to this method is made for a room that is currently being released, then this it returns only when
+     * the release operation is complete.
+     *
+     * If a call to this method is made, followed by a subsequent call to `release(roomID:)` before the `get(roomID:options:)` returns, then the
+     * promise will throw an error.
+     *
+     * - Parameters:
+     *   - roomID: The ID of the room.
+     *   - options: The options for the room.
+     *
+     * - Returns: A new or existing `Room` object.
+     *
+     * - Throws: `ARTErrorInfo` if a room with the same ID but different options already exists.
+     */
     func get(roomID: String, options: RoomOptions) async throws -> any Room
+
+    /**
+     * Release the ``Room`` object if it exists. This method only releases the reference
+     * to the Room object from the Rooms instance and detaches the room from Ably. It does not unsubscribe to any
+     * events.
+     *
+     * After calling this function, the room object is no-longer usable. If you wish to get the room object again,
+     * you must call ``Rooms/get(roomID:options:)``.
+     *
+     * Calling this function will abort any in-progress `get(roomID:options:)` calls for the same room.
+     *
+     * - Parameters:
+     *   - roomID: The ID of the room.
+     */
     func release(roomID: String) async
+
+    /**
+     * Get the client options used to create the chat instance.
+     *
+     * - Returns: ``ClientOptions`` object.
+     */
     var clientOptions: ClientOptions { get }
 }
 

--- a/Sources/AblyChat/Typing.swift
+++ b/Sources/AblyChat/Typing.swift
@@ -1,14 +1,59 @@
 import Ably
 
+/**
+ * This interface is used to interact with typing in a chat room including subscribing to typing events and
+ * fetching the current set of typing clients.
+ *
+ * Get an instance via ``Room/typing``.
+ */
 public protocol Typing: AnyObject, Sendable, EmitsDiscontinuities {
+    /**
+     * Subscribes a given listener to all typing events from users in the chat room.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``TypingEvent`` events.
+     */
     func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<TypingEvent>
-    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Typing` protocol provides a default implementation of this method.
     func subscribe() async -> Subscription<TypingEvent>
+
+    /**
+     * Get the current typers, a set of clientIds.
+     *
+     * - Returns: A set of clientIds that are currently typing.
+     */
     func get() async throws -> Set<String>
+
+    /**
+     * Start indicates that the current user is typing. This will emit a ``TypingEvent`` event to inform listening clients and begin a timer,
+     * once the timer expires, another ``TypingEvent`` event will be emitted. In both cases ``TypingEvent/currentlyTyping``
+     * contains a list of userIds who are currently typing.
+     *
+     * The timeout is configurable through the ``TypingOptions/timeout`` parameter.
+     * If the current user is already typing, it will reset the timer and begin counting down again without emitting a new event.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func start() async throws
+
+    /**
+     * Stop indicates that the current user has stopped typing. This will emit a ``TypingEvent`` event to inform listening clients,
+     * and immediately clear the typing timeout timer.
+     *
+     * - Throws: An `ARTErrorInfo`.
+     */
     func stop() async throws
+
+    /**
+     * Get the Ably realtime channel underpinning typing events.
+     *
+     * - Returns: The Ably realtime channel.
+     */
     var channel: RealtimeChannelProtocol { get }
 }
 
@@ -18,7 +63,13 @@ public extension Typing {
     }
 }
 
+/**
+ * Represents a typing event.
+ */
 public struct TypingEvent: Sendable {
+    /**
+     * Get a set of clientIds that are currently typing.
+     */
     public var currentlyTyping: Set<String>
 
     public init(currentlyTyping: Set<String>) {


### PR DESCRIPTION
**Note: This PR is based on top of #163.**

WIP for #1. What's here so far:

- fixes some existing documentation comments to make DocC happy
- adds a CI job to run the DocC documentation compiler; this gives us checking of links to other symbols and a (rather overwhelming) documentation coverage report
- Started copying across the documentation comments from the JS repo at `58a4fa2`; the first few documentation comments are copied across with some light editing to match the Swift documentation syntax, but when it started to become clear that we were going to need deeper edits for a bunch of stuff I switched over to copying them over without any editing; we will have to do a second pass for editing. See commit messages for current progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job in the GitHub Actions workflow for checking documentation.
	- Added new dependencies for documentation generation support.
	- Enhanced logging functionality with structured logging levels.
	- Introduced new structs and enums for improved event handling and error management.

- **Documentation**
	- Extensive documentation improvements across various protocols, structs, and methods, enhancing clarity and usability.
	- Added documentation comments for new and existing properties, methods, and enums.

- **Bug Fixes**
	- Updated error handling in several protocols to improve robustness.

- **Chores**
	- Updated `.gitignore` to ignore documentation coverage reports.
	- Added a command for building documentation in the build tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->