### PR TITLE
Rename Subscription’s `finish` method to `unsubscribe`

### DIFF
--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -72,7 +72,7 @@ public struct Subscription<Element: Sendable>: Sendable, AsyncSequence {
     }
 
     // TODO: https://github.com/ably-labs/ably-chat-swift/issues/36 Revisit how we want to unsubscribe to fulfil CHA-M4b & CHA-ER4b. I think exposing this publicly for all Subscription types is suitable.
-    public func finish() {
+    public func unsubscribe() {
         switch mode {
         case let .default(_, continuation):
             continuation.finish()


### PR DESCRIPTION
I don’t think that this method should exist at all; the intention for our public API, as described in 20e7f5f, is that the user should not need to explicitly unsubscribe. (We have #36 for figuring out how to implement the appropriate cleanup.) However, this method does now exist, and we’re probably not going to get rid of it before beta, so we agreed in standup today to at least name it in line with JS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed the `finish()` method to `unsubscribe()` for better clarity in subscription management.

- **Bug Fixes**
	- No functional changes; the `unsubscribe()` method retains the same functionality as the previous `finish()` method. 

- **Documentation**
	- Updated method name to improve understanding of its purpose in the context of managing subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->