### PR TITLE
Add an “all features enabled” room option

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -56,12 +56,7 @@ struct ContentView: View {
     private func room() async throws -> Room {
         try await chatClient.rooms.get(
             roomID: roomID,
-            options: .init(
-                presence: .init(),
-                typing: .init(),
-                reactions: .init(),
-                occupancy: .init()
-            )
+            options: .allFeaturesEnabled
         )
     }
 

--- a/Sources/AblyChat/RoomOptions.swift
+++ b/Sources/AblyChat/RoomOptions.swift
@@ -6,6 +6,14 @@ public struct RoomOptions: Sendable, Equatable {
     public var reactions: RoomReactionsOptions?
     public var occupancy: OccupancyOptions?
 
+    /// A `RoomOptions` which enables all room features, using the default settings for each feature.
+    public static let allFeaturesEnabled: Self = .init(
+        presence: .init(),
+        typing: .init(),
+        reactions: .init(),
+        occupancy: .init()
+    )
+
     public init(presence: PresenceOptions? = nil, typing: TypingOptions? = nil, reactions: RoomReactionsOptions? = nil, occupancy: OccupancyOptions? = nil) {
         self.presence = presence
         self.typing = typing


### PR DESCRIPTION
In 20e7f5f I said

> RoomOptionsDefaults in JS is instead implemented here by giving the
> *Options types a no-args initializer that populates the default values.

but I had not noticed that JS’s RoomOptionsDefaults is not actually a “default”, since the JS SDK does not even have a concept of a “default” RoomOptions. What it actually is is a RoomOptions in which all of the room features are switched on; we discussed this today in standup and Andy said that the intention of this value was to give users who are just playing around with the SDK an easy way to turn all features on. So, here, I add such an API for Swift, but with a name that more accurately describes its intention. Andy’s created [1] to revisit the JS naming.

[1] https://ably.atlassian.net/browse/CHA-766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified room data retrieval with a new `allFeaturesEnabled` option for room configurations.
	- Enhanced chat interface with dynamic reaction behaviors through new properties for rotation speed and angle.

- **Bug Fixes**
	- Maintained existing error handling and control flow to ensure application stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->