### PR TITLE
[ECO-5149] Implement lifecycle contributor precedence

### DIFF
--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -1,12 +1,13 @@
 import Ably
 
 /// The features offered by a chat room.
-internal enum RoomFeature {
+internal enum RoomFeature: CaseIterable {
+    // This list MUST be kept in the same order as the list in CHA-RC2e, in order for the implementation of `areInPrecedenceListOrder` to work.
     case messages
     case presence
+    case typing
     case reactions
     case occupancy
-    case typing
 
     internal func channelNameForRoomID(_ roomID: String) -> String {
         "\(roomID)::$chat::$\(channelNameSuffix)"
@@ -26,6 +27,14 @@ internal enum RoomFeature {
             // (CHA-T1) Typing Indicators for a Room is exposed on a dedicated Realtime channel. These channels use the format <roomId>::$chat::$typingIndicators. For example, if your room id is my-room then the typing channel will be my-room::$chat::$typingIndicators.
             "typingIndicators"
         }
+    }
+
+    /// Returns a `Bool` indicating whether `first` and `second` are in the same order as the list given in CHA-RC2e.
+    internal static func areInPrecedenceListOrder(_ first: Self, _ second: Self) -> Bool {
+        let allCases = Self.allCases
+        let indexOfFirst = allCases.firstIndex(of: first)!
+        let indexOfSecond = allCases.firstIndex(of: second)!
+        return indexOfFirst < indexOfSecond
     }
 }
 


### PR DESCRIPTION
Implements spec points CHA-RC2e and CHA-RL10.

Resolves #153.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for room features, ensuring clarity when accessing properties without enabled features.
	- Reintroduction of the `typing` feature in the room feature set.

- **Bug Fixes**
	- Improved initialization process for room contributors, ensuring correct order of feature processing.

- **Tests**
	- Added a new test to verify the order of contributors in the `DefaultRoom` when all features are enabled, enhancing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->