### PR TITLE
Add an initial release process and `CHANGELOG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## [0.1.0](https://github.com/ably/ably-chat-swift/tree/0.1.0)
+
+Nothing here, yet. We’ll add a summary of the initial version here once we release it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,19 @@ Example:
 ```swift
 // @specUntested CHA-EX2b - I was unable to find a way to test this spec point in an environment in which concurrency is being used; there is no obvious moment at which to stop observing the emitted state changes in order to be sure that FAILED has not been emitted twice.
 ```
+
+## Release process
+
+For each release, the following needs to be done:
+
+- Create a new branch `release/x.x.x` (where `x.x.x` is the new version number) from the `main` branch
+- Update the `version` constant in [`Sources/AblyChat/Version.swift`](Sources/AblyChat/Version.swift)
+- Go to [Github releases](https://github.com/ably/ably-chat-swift/releases) and press the `Draft a new release` button. Choose your new branch as a target
+- Press the `Choose a tag` dropdown and start typing a new tag, Github will suggest the `Create new tag x.x.x on publish` option. After you select it Github will unveil the `Generate release notes` button
+- From the newly generated changes remove everything that don't make much sense to the library user
+- Copy the final list of changes to the top of the `CHANGELOG.md` file. Modify as necessary to fit the existing format of this file
+- Commit these changes and push to the origin `git add CHANGELOG.md && git commit -m "Update change log." && git push -u origin release/x.x.x`
+- Make a pull request against `main` and await approval of reviewer(s)
+- Once approved and/or any additional commits have been added, merge the PR
+- After merging the PR, wait for all CI jobs for `main` to pass.
+- Publish your drafted release (refer to previous releases for release notes format)


### PR DESCRIPTION
Release process copied from ably-cocoa at `aca9a7c`, with some modifications.

These instructions are untested, and there will probably be stuff to modify once we’ve actually done a release.

(Also, the “refer to previous releases” guidance for release notes doesn’t work well yet!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Change Log" section in the `CHANGELOG.md` file with an entry for version `0.1.0`.
	- Added a "Release process" section in the `CONTRIBUTING.md` file detailing steps for creating a new release.

- **Documentation**
	- Updated documentation to include release procedures and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->