### PR TITLE
[ECO-5167] Make `bufferingPolicy` parameter optional in public API

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -206,7 +206,7 @@ struct ContentView: View {
 
         // Continue listening for new presence events on a background task so this function can return
         Task {
-            for await event in try await room().presence.subscribe(events: [.enter, .leave, .update]) {
+            for await event in try await room().presence.subscribe(events: [.enter, .leave, .update], bufferingPolicy: .unbounded) {
                 withAnimation {
                     let status = event.data?.userCustomData?["status"]?.value as? String
                     let clientPresenceChangeMessage = "\(event.clientID) \(event.action.displayedText)"

--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -169,7 +169,7 @@ struct ContentView: View {
     }
 
     func showMessages() async throws {
-        let messagesSubscription = try await room().messages.subscribe(bufferingPolicy: .unbounded)
+        let messagesSubscription = try await room().messages.subscribe()
         let previousMessages = try await messagesSubscription.getPreviousMessages(params: .init())
 
         for message in previousMessages.items {
@@ -189,7 +189,7 @@ struct ContentView: View {
     }
 
     func showReactions() async throws {
-        let reactionSubscription = try await room().reactions.subscribe(bufferingPolicy: .unbounded)
+        let reactionSubscription = try await room().reactions.subscribe()
 
         // Continue listening for reactions on a background task so this function can return
         Task {
@@ -206,7 +206,7 @@ struct ContentView: View {
 
         // Continue listening for new presence events on a background task so this function can return
         Task {
-            for await event in try await room().presence.subscribe(events: [.enter, .leave, .update], bufferingPolicy: .unbounded) {
+            for await event in try await room().presence.subscribe(events: [.enter, .leave, .update]) {
                 withAnimation {
                     let status = event.data?.userCustomData?["status"]?.value as? String
                     let clientPresenceChangeMessage = "\(event.clientID) \(event.action.displayedText)"
@@ -219,7 +219,7 @@ struct ContentView: View {
     }
 
     func showTypings() async throws {
-        let typingSubscription = try await room().typing.subscribe(bufferingPolicy: .unbounded)
+        let typingSubscription = try await room().typing.subscribe()
         // Continue listening for typing events on a background task so this function can return
         Task {
             for await typing in typingSubscription {
@@ -241,7 +241,7 @@ struct ContentView: View {
         }
 
         Task {
-            for await event in try await room().occupancy.subscribe(bufferingPolicy: .unbounded) {
+            for await event in try await room().occupancy.subscribe() {
                 withAnimation {
                     occupancyInfo = "Connections: \(event.presenceMembers) (\(event.connections))"
                 }
@@ -250,7 +250,7 @@ struct ContentView: View {
     }
 
     func printConnectionStatusChange() async {
-        let connectionSubsciption = chatClient.connection.onStatusChange(bufferingPolicy: .unbounded)
+        let connectionSubsciption = chatClient.connection.onStatusChange()
 
         // Continue listening for connection status change on a background task so this function can return
         Task {
@@ -263,7 +263,7 @@ struct ContentView: View {
     func showRoomStatus() async throws {
         // Continue listening for status change events on a background task so this function can return
         Task {
-            for await status in try await room().onStatusChange(bufferingPolicy: .unbounded) {
+            for await status in try await room().onStatusChange() {
                 withAnimation {
                     if status.current.isAttaching {
                         statusInfo = "\(status.current)...".capitalized

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -144,7 +144,7 @@ actor MockMessages: Messages {
         return message
     }
 
-    func subscribeToDiscontinuities() -> Subscription<DiscontinuityEvent> {
+    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -195,7 +195,7 @@ actor MockRoomReactions: RoomReactions {
         .init(mockAsyncSequence: createSubscription())
     }
 
-    func subscribeToDiscontinuities() -> Subscription<DiscontinuityEvent> {
+    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -244,7 +244,7 @@ actor MockTyping: Typing {
         }
     }
 
-    func subscribeToDiscontinuities() -> Subscription<DiscontinuityEvent> {
+    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -340,15 +340,15 @@ actor MockPresence: Presence {
         }
     }
 
-    func subscribe(event _: PresenceEventType) -> Subscription<PresenceEvent> {
+    func subscribe(event _: PresenceEventType, bufferingPolicy _: BufferingPolicy) -> Subscription<PresenceEvent> {
         .init(mockAsyncSequence: createSubscription())
     }
 
-    func subscribe(events _: [PresenceEventType]) -> Subscription<PresenceEvent> {
+    func subscribe(events _: [PresenceEventType], bufferingPolicy _: BufferingPolicy) -> Subscription<PresenceEvent> {
         .init(mockAsyncSequence: createSubscription())
     }
 
-    func subscribeToDiscontinuities() -> Subscription<DiscontinuityEvent> {
+    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -383,7 +383,7 @@ actor MockOccupancy: Occupancy {
         OccupancyEvent(connections: 10, presenceMembers: 5)
     }
 
-    func subscribeToDiscontinuities() -> Subscription<DiscontinuityEvent> {
+    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }

--- a/Example/AblyChatExample/Mocks/MockSubscription.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscription.swift
@@ -20,7 +20,7 @@ struct MockSubscription<T: Sendable>: Sendable, AsyncSequence {
     }
 
     init(randomElement: @escaping @Sendable () -> Element, interval: Double) {
-        let (stream, continuation) = AsyncStream.makeStream(of: Element.self, bufferingPolicy: .unbounded)
+        let (stream, continuation) = AsyncStream.makeStream(of: Element.self)
         self.continuation = continuation
         let timer: AsyncTimerSequence<ContinuousClock> = .init(interval: .seconds(interval), clock: .init())
         mergedSequence = merge(stream, timer.map { _ in

--- a/Sources/AblyChat/Connection.swift
+++ b/Sources/AblyChat/Connection.swift
@@ -5,6 +5,16 @@ public protocol Connection: AnyObject, Sendable {
     // TODO: (https://github.com/ably-labs/ably-chat-swift/issues/12): consider how to avoid the need for an unwrap
     var error: ARTErrorInfo? { get async }
     func onStatusChange(bufferingPolicy: BufferingPolicy) -> Subscription<ConnectionStatusChange>
+    /// Same as calling ``onStatusChange(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Connection` protocol provides a default implementation of this method.
+    func onStatusChange() -> Subscription<ConnectionStatusChange>
+}
+
+public extension Connection {
+    func onStatusChange() -> Subscription<ConnectionStatusChange> {
+        onStatusChange(bufferingPolicy: .unbounded)
+    }
 }
 
 public enum ConnectionStatus: Sendable {

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -109,8 +109,8 @@ internal final class DefaultMessages: Messages, EmitsDiscontinuities {
     }
 
     // (CHA-M7) Users may subscribe to discontinuity events to know when there’s been a break in messages that they need to resolve. Their listener will be called when a discontinuity event is triggered from the room lifecycle.
-    internal func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities()
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
     }
 
     private func getBeforeSubscriptionStart(_ uuid: UUID, params: QueryOptions) async throws -> any PaginatedResult<Message> {

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -50,7 +50,7 @@ internal final class DefaultOccupancy: Occupancy, EmitsDiscontinuities {
     }
 
     // (CHA-O5) Users may subscribe to discontinuity events to know when there’s been a break in occupancy. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For occupancy, there shouldn’t need to be user action as most channels will send occupancy updates regularly as clients churn.
-    internal func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities()
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
     }
 }

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -164,9 +164,9 @@ internal final class DefaultPresence: Presence, EmitsDiscontinuities {
 
     // (CHA-PR7a) Users may provide a listener to subscribe to all presence events in a room.
     // (CHA-PR7b) Users may provide a listener and a list of selected presence events, to subscribe to just those events in a room.
-    internal func subscribe(event: PresenceEventType) async -> Subscription<PresenceEvent> {
+    internal func subscribe(event: PresenceEventType, bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent> {
         logger.log(message: "Subscribing to presence events", level: .debug)
-        let subscription = Subscription<PresenceEvent>(bufferingPolicy: .unbounded)
+        let subscription = Subscription<PresenceEvent>(bufferingPolicy: bufferingPolicy)
         channel.presence.subscribe(event.toARTPresenceAction()) { [processPresenceSubscribe, logger] message in
             logger.log(message: "Received presence message: \(message)", level: .debug)
             Task {
@@ -178,9 +178,9 @@ internal final class DefaultPresence: Presence, EmitsDiscontinuities {
         return subscription
     }
 
-    internal func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent> {
+    internal func subscribe(events: [PresenceEventType], bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent> {
         logger.log(message: "Subscribing to presence events", level: .debug)
-        let subscription = Subscription<PresenceEvent>(bufferingPolicy: .unbounded)
+        let subscription = Subscription<PresenceEvent>(bufferingPolicy: bufferingPolicy)
         for event in events {
             channel.presence.subscribe(event.toARTPresenceAction()) { [processPresenceSubscribe, logger] message in
                 logger.log(message: "Received presence message: \(message)", level: .debug)
@@ -194,8 +194,8 @@ internal final class DefaultPresence: Presence, EmitsDiscontinuities {
     }
 
     // (CHA-PR8) Users may subscribe to discontinuity events to know when there’s been a break in presence. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For presence, there shouldn’t need to be user action as the underlying core SDK will heal the presence set.
-    internal func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities()
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
     }
 
     private func decodePresenceData(from data: Any?) -> PresenceData? {

--- a/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
+++ b/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
@@ -18,8 +18,8 @@ internal actor DefaultRoomLifecycleContributor: RoomLifecycleContributor, EmitsD
         }
     }
 
-    internal func subscribeToDiscontinuities() -> Subscription<DiscontinuityEvent> {
-        let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: .unbounded)
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+        let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: bufferingPolicy)
         // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         discontinuitySubscriptions.append(subscription)
         return subscription

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -80,8 +80,8 @@ internal final class DefaultRoomReactions: RoomReactions, EmitsDiscontinuities {
     }
 
     // (CHA-ER5) Users may subscribe to discontinuity events to know when there’s been a break in reactions that they need to resolve. Their listener will be called when a discontinuity event is triggered from the room lifecycle.
-    internal func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities()
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
     }
 
     private enum RoomReactionsError: Error {

--- a/Sources/AblyChat/DefaultTyping.swift
+++ b/Sources/AblyChat/DefaultTyping.swift
@@ -22,7 +22,7 @@ internal final class DefaultTyping: Typing {
 
     // (CHA-T6) Users may subscribe to typing events – updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
     internal func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<TypingEvent> {
-        let subscription = Subscription<TypingEvent>(bufferingPolicy: .unbounded)
+        let subscription = Subscription<TypingEvent>(bufferingPolicy: bufferingPolicy)
         let eventTracker = EventTracker()
 
         channel.presence.subscribe { [weak self] message in

--- a/Sources/AblyChat/DefaultTyping.swift
+++ b/Sources/AblyChat/DefaultTyping.swift
@@ -160,8 +160,8 @@ internal final class DefaultTyping: Typing {
     }
 
     // (CHA-T7) Users may subscribe to discontinuity events to know when there’s been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn’t need to be user action as the underlying core SDK will heal the presence set.
-    internal func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities()
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
     }
 
     private func processPresenceGet(members: [ARTPresenceMessage]?, error: ARTErrorInfo?) throws -> Set<String> {

--- a/Sources/AblyChat/EmitsDiscontinuities.swift
+++ b/Sources/AblyChat/EmitsDiscontinuities.swift
@@ -10,5 +10,5 @@ public struct DiscontinuityEvent: Sendable, Equatable {
 }
 
 public protocol EmitsDiscontinuities {
-    func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent>
+    func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent>
 }

--- a/Sources/AblyChat/EmitsDiscontinuities.swift
+++ b/Sources/AblyChat/EmitsDiscontinuities.swift
@@ -11,4 +11,14 @@ public struct DiscontinuityEvent: Sendable, Equatable {
 
 public protocol EmitsDiscontinuities {
     func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent>
+    /// Same as calling ``subscribeToDiscontinuities(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `EmitsDiscontinuities` protocol provides a default implementation of this method.
+    func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent>
+}
+
+public extension EmitsDiscontinuities {
+    func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
+        await subscribeToDiscontinuities(bufferingPolicy: .unbounded)
+    }
 }

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -2,9 +2,19 @@ import Ably
 
 public protocol Messages: AnyObject, Sendable, EmitsDiscontinuities {
     func subscribe(bufferingPolicy: BufferingPolicy) async throws -> MessageSubscription
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Messages` protocol provides a default implementation of this method.
+    func subscribe() async throws -> MessageSubscription
     func get(options: QueryOptions) async throws -> any PaginatedResult<Message>
     func send(params: SendMessageParams) async throws -> Message
     var channel: RealtimeChannelProtocol { get }
+}
+
+public extension Messages {
+    func subscribe() async throws -> MessageSubscription {
+        try await subscribe(bufferingPolicy: .unbounded)
+    }
 }
 
 public struct SendMessageParams: Sendable {

--- a/Sources/AblyChat/Occupancy.swift
+++ b/Sources/AblyChat/Occupancy.swift
@@ -2,8 +2,18 @@ import Ably
 
 public protocol Occupancy: AnyObject, Sendable, EmitsDiscontinuities {
     func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<OccupancyEvent>
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Occupancy` protocol provides a default implementation of this method.
+    func subscribe() async -> Subscription<OccupancyEvent>
     func get() async throws -> OccupancyEvent
     var channel: RealtimeChannelProtocol { get }
+}
+
+public extension Occupancy {
+    func subscribe() async -> Subscription<OccupancyEvent> {
+        await subscribe(bufferingPolicy: .unbounded)
+    }
 }
 
 // (CHA-O2) The occupancy event format is shown here (https://sdk.ably.com/builds/ably/specification/main/chat-features/#chat-structs-occupancy-event)

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -83,7 +83,25 @@ public protocol Presence: AnyObject, Sendable, EmitsDiscontinuities {
     func update(data: PresenceData?) async throws
     func leave(data: PresenceData?) async throws
     func subscribe(event: PresenceEventType, bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
+    /// Same as calling ``subscribe(event:bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Presence` protocol provides a default implementation of this method.
+    func subscribe(event: PresenceEventType) async -> Subscription<PresenceEvent>
     func subscribe(events: [PresenceEventType], bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
+    /// Same as calling ``subscribe(events:bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Presence` protocol provides a default implementation of this method.
+    func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent>
+}
+
+public extension Presence {
+    func subscribe(event: PresenceEventType) async -> Subscription<PresenceEvent> {
+        await subscribe(event: event, bufferingPolicy: .unbounded)
+    }
+
+    func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent> {
+        await subscribe(events: events, bufferingPolicy: .unbounded)
+    }
 }
 
 public struct PresenceMember: Sendable {

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -82,8 +82,8 @@ public protocol Presence: AnyObject, Sendable, EmitsDiscontinuities {
     func enter(data: PresenceData?) async throws
     func update(data: PresenceData?) async throws
     func leave(data: PresenceData?) async throws
-    func subscribe(event: PresenceEventType) async -> Subscription<PresenceEvent>
-    func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent>
+    func subscribe(event: PresenceEventType, bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
+    func subscribe(events: [PresenceEventType], bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
 }
 
 public struct PresenceMember: Sendable {

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -14,9 +14,19 @@ public protocol Room: AnyObject, Sendable {
     // TODO: change to `status`
     var status: RoomStatus { get async }
     func onStatusChange(bufferingPolicy: BufferingPolicy) async -> Subscription<RoomStatusChange>
+    /// Same as calling ``onStatusChange(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Room` protocol provides a default implementation of this method.
+    func onStatusChange() async -> Subscription<RoomStatusChange>
     func attach() async throws
     func detach() async throws
     var options: RoomOptions { get }
+}
+
+public extension Room {
+    func onStatusChange() async -> Subscription<RoomStatusChange> {
+        await onStatusChange(bufferingPolicy: .unbounded)
+    }
 }
 
 /// A ``Room`` that exposes additional functionality for use within the SDK.

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -57,8 +57,8 @@ internal struct DefaultFeatureChannel: FeatureChannel {
     internal var contributor: DefaultRoomLifecycleContributor
     internal var roomLifecycleManager: RoomLifecycleManager
 
-    internal func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await contributor.subscribeToDiscontinuities()
+    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await contributor.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
     }
 
     internal func waitToBeAbleToPerformPresenceOperations(requestedByFeature requester: RoomFeature) async throws(ARTErrorInfo) {

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -4,6 +4,16 @@ public protocol RoomReactions: AnyObject, Sendable, EmitsDiscontinuities {
     func send(params: SendReactionParams) async throws
     var channel: RealtimeChannelProtocol { get }
     func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<Reaction>
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `RoomReactions` protocol provides a default implementation of this method.
+    func subscribe() async -> Subscription<Reaction>
+}
+
+public extension RoomReactions {
+    func subscribe() async -> Subscription<Reaction> {
+        await subscribe(bufferingPolicy: .unbounded)
+    }
 }
 
 public struct SendReactionParams: Sendable {

--- a/Sources/AblyChat/Typing.swift
+++ b/Sources/AblyChat/Typing.swift
@@ -2,10 +2,20 @@ import Ably
 
 public protocol Typing: AnyObject, Sendable, EmitsDiscontinuities {
     func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<TypingEvent>
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    ///
+    /// The `Typing` protocol provides a default implementation of this method.
+    func subscribe() async -> Subscription<TypingEvent>
     func get() async throws -> Set<String>
     func start() async throws
     func stop() async throws
     var channel: RealtimeChannelProtocol { get }
+}
+
+public extension Typing {
+    func subscribe() async -> Subscription<TypingEvent> {
+        await subscribe(bufferingPolicy: .unbounded)
+    }
 }
 
 public struct TypingEvent: Sendable {

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -17,7 +17,7 @@ struct DefaultMessagesTests {
         // Then
         await #expect(throws: ARTErrorInfo.create(withCode: 40000, status: 400, message: "channel is attached, but channelSerial is not defined"), performing: {
             // When
-            try await defaultMessages.subscribe(bufferingPolicy: .unbounded)
+            try await defaultMessages.subscribe()
         })
     }
 
@@ -56,7 +56,7 @@ struct DefaultMessagesTests {
         )
         let featureChannel = MockFeatureChannel(channel: channel)
         let defaultMessages = await DefaultMessages(featureChannel: featureChannel, chatAPI: chatAPI, roomID: "basketball", clientID: "clientId", logger: TestLogger())
-        let subscription = try await defaultMessages.subscribe(bufferingPolicy: .unbounded)
+        let subscription = try await defaultMessages.subscribe()
         let expectedPaginatedResult = PaginatedResultWrapper<Message>(
             paginatedResponse: MockHTTPPaginatedResponse.successGetMessagesWithNoItems,
             items: []
@@ -81,7 +81,7 @@ struct DefaultMessagesTests {
 
         // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
         let featureChannelDiscontinuity = DiscontinuityEvent(error: ARTErrorInfo.createUnknownError() /* arbitrary */ )
-        let messagesDiscontinuitySubscription = await messages.subscribeToDiscontinuities(bufferingPolicy: .unbounded)
+        let messagesDiscontinuitySubscription = await messages.subscribeToDiscontinuities()
         await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
 
         // Then: The DefaultMessages instance emits this discontinuity through `subscribeToDiscontinuities`

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -81,7 +81,7 @@ struct DefaultMessagesTests {
 
         // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
         let featureChannelDiscontinuity = DiscontinuityEvent(error: ARTErrorInfo.createUnknownError() /* arbitrary */ )
-        let messagesDiscontinuitySubscription = await messages.subscribeToDiscontinuities()
+        let messagesDiscontinuitySubscription = await messages.subscribeToDiscontinuities(bufferingPolicy: .unbounded)
         await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
 
         // Then: The DefaultMessages instance emits this discontinuity through `subscribeToDiscontinuities`

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -72,7 +72,7 @@ struct DefaultRoomReactionsTests {
 
         // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
         let featureChannelDiscontinuity = DiscontinuityEvent(error: ARTErrorInfo.createUnknownError() /* arbitrary */ )
-        let messagesDiscontinuitySubscription = await roomReactions.subscribeToDiscontinuities()
+        let messagesDiscontinuitySubscription = await roomReactions.subscribeToDiscontinuities(bufferingPolicy: .unbounded)
         await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
 
         // Then: The DefaultRoomReactions instance emits this discontinuity through `subscribeToDiscontinuities`

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -55,7 +55,7 @@ struct DefaultRoomReactionsTests {
         let defaultRoomReactions = await DefaultRoomReactions(featureChannel: featureChannel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
 
         // When
-        let subscription: Subscription<Reaction>? = await defaultRoomReactions.subscribe(bufferingPolicy: .unbounded)
+        let subscription: Subscription<Reaction>? = await defaultRoomReactions.subscribe()
 
         // Then
         #expect(subscription != nil)
@@ -72,7 +72,7 @@ struct DefaultRoomReactionsTests {
 
         // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
         let featureChannelDiscontinuity = DiscontinuityEvent(error: ARTErrorInfo.createUnknownError() /* arbitrary */ )
-        let messagesDiscontinuitySubscription = await roomReactions.subscribeToDiscontinuities(bufferingPolicy: .unbounded)
+        let messagesDiscontinuitySubscription = await roomReactions.subscribeToDiscontinuities()
         await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
 
         // Then: The DefaultRoomReactions instance emits this discontinuity through `subscribeToDiscontinuities`

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -284,7 +284,7 @@ struct DefaultRoomTests {
 
         // When: The room lifecycle manager emits a status change through `subscribeToState`
         let managerStatusChange = RoomStatusChange(current: .detached, previous: .detaching) // arbitrary
-        let roomStatusSubscription = await room.onStatusChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await room.onStatusChange()
         await lifecycleManager.emitStatusChange(managerStatusChange)
 
         // Then: The room emits this status change through `onStatusChange`

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -84,7 +84,7 @@ struct IntegrationTests {
         )
 
         // (3) Subscribe to room status
-        let rxRoomStatusSubscription = await rxRoom.onStatusChange(bufferingPolicy: .unbounded)
+        let rxRoomStatusSubscription = await rxRoom.onStatusChange()
 
         // (4) Attach the room so we can receive messages on it
         try await rxRoom.attach()
@@ -98,7 +98,7 @@ struct IntegrationTests {
         // (1) Send a message before subscribing to messages, so that later on we can check history works.
 
         // (2) Create a throwaway subscription and wait for it to receive a message. This is to make sure that rxRoom has seen the message that we send here, so that the first message we receive on the subscription created in (5) is that which we’ll send in (6), and not that which we send here.
-        let throwawayRxMessageSubscription = try await rxRoom.messages.subscribe(bufferingPolicy: .unbounded)
+        let throwawayRxMessageSubscription = try await rxRoom.messages.subscribe()
 
         // (3) Send the message
         let txMessageBeforeRxSubscribe = try await txRoom.messages.send(params: .init(text: "Hello from txRoom, before rxRoom subscribe"))
@@ -108,7 +108,7 @@ struct IntegrationTests {
         #expect(throwawayRxMessage == txMessageBeforeRxSubscribe)
 
         // (5) Subscribe to messages
-        let rxMessageSubscription = try await rxRoom.messages.subscribe(bufferingPolicy: .unbounded)
+        let rxMessageSubscription = try await rxRoom.messages.subscribe()
 
         // (6) Now that we’re subscribed to messages, send a message on the other client and check that we receive it on the subscription
         let txMessageAfterRxSubscribe = try await txRoom.messages.send(params: .init(text: "Hello from txRoom, after rxRoom subscribe"))
@@ -152,7 +152,7 @@ struct IntegrationTests {
         // MARK: - Reactions
 
         // (1) Subscribe to reactions
-        let rxReactionSubscription = await rxRoom.reactions.subscribe(bufferingPolicy: .unbounded)
+        let rxReactionSubscription = await rxRoom.reactions.subscribe()
 
         // (2) Now that we’re subscribed to reactions, send a reaction on the other client and check that we receive it on the subscription
         try await txRoom.reactions.send(params: .init(type: "heart"))
@@ -170,7 +170,7 @@ struct IntegrationTests {
         #expect(currentOccupancy.presenceMembers == 0) // not yet entered presence
 
         // (2) Subscribe to occupancy
-        let rxOccupancySubscription = await rxRoom.occupancy.subscribe(bufferingPolicy: .unbounded)
+        let rxOccupancySubscription = await rxRoom.occupancy.subscribe()
 
         // (3) Attach the room so we can perform presence operations
         try await txRoom.attach()
@@ -202,7 +202,7 @@ struct IntegrationTests {
         // MARK: - Presence
 
         // (1) Subscribe to presence
-        let rxPresenceSubscription = await rxRoom.presence.subscribe(events: [.enter, .leave, .update], bufferingPolicy: .unbounded)
+        let rxPresenceSubscription = await rxRoom.presence.subscribe(events: [.enter, .leave, .update])
 
         // (2) Send `.enter` presence event with custom data on the other client and check that we receive it on the subscription
         try await txRoom.presence.enter(data: .init(userCustomData: ["randomData": .string("randomValue")]))
@@ -243,7 +243,7 @@ struct IntegrationTests {
         // MARK: - Typing Indicators
 
         // (1) Subscribe to typing indicators
-        let rxTypingSubscription = await rxRoom.typing.subscribe(bufferingPolicy: .unbounded)
+        let rxTypingSubscription = await rxRoom.typing.subscribe()
 
         // (2) Start typing on txRoom and check that we receive the typing event on the subscription
         try await txRoom.typing.start()

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -202,7 +202,7 @@ struct IntegrationTests {
         // MARK: - Presence
 
         // (1) Subscribe to presence
-        let rxPresenceSubscription = await rxRoom.presence.subscribe(events: [.enter, .leave, .update])
+        let rxPresenceSubscription = await rxRoom.presence.subscribe(events: [.enter, .leave, .update], bufferingPolicy: .unbounded)
 
         // (2) Send `.enter` presence event with custom data on the other client and check that we receive it on the subscription
         try await txRoom.presence.enter(data: .init(userCustomData: ["randomData": .string("randomValue")]))

--- a/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
@@ -15,8 +15,8 @@ final actor MockFeatureChannel: FeatureChannel {
         resultOfWaitToBeAbleToPerformPresenceOperations = resultOfWaitToBeAblePerformPresenceOperations
     }
 
-    func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: .unbounded)
+    func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: bufferingPolicy)
         discontinuitySubscriptions.append(subscription)
         return subscription
     }


### PR DESCRIPTION
Use a default buffering policy of `.unbounded`. Also, I’ve added some missing `bufferingPolicy` parameters that for some reason I forgot to include in 20e7f5f. See commit messages for more details.

Resolves #172.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Simplified subscription methods for messages, reactions, typing, and occupancy, enhancing user experience.
  - Added new properties for reaction animations, improving visual feedback.

- **Bug Fixes**
  - Enhanced error handling in various subscription methods to ensure robustness.

- **Documentation**
  - Updated protocol methods to provide clearer subscription options and defaults.

- **Refactor**
  - Streamlined method signatures across multiple components to improve clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->