### PR TITLE
[ECO-5168] Rename `subscribeToDiscontinuities` to `onDiscontinuity`

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -144,7 +144,7 @@ actor MockMessages: Messages {
         return message
     }
 
-    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+    func onDiscontinuity(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -195,7 +195,7 @@ actor MockRoomReactions: RoomReactions {
         .init(mockAsyncSequence: createSubscription())
     }
 
-    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+    func onDiscontinuity(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -244,7 +244,7 @@ actor MockTyping: Typing {
         }
     }
 
-    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+    func onDiscontinuity(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -348,7 +348,7 @@ actor MockPresence: Presence {
         .init(mockAsyncSequence: createSubscription())
     }
 
-    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+    func onDiscontinuity(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }
@@ -383,7 +383,7 @@ actor MockOccupancy: Occupancy {
         OccupancyEvent(connections: 10, presenceMembers: 5)
     }
 
-    func subscribeToDiscontinuities(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+    func onDiscontinuity(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         fatalError("Not yet implemented")
     }
 }

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -109,8 +109,8 @@ internal final class DefaultMessages: Messages, EmitsDiscontinuities {
     }
 
     // (CHA-M7) Users may subscribe to discontinuity events to know when there’s been a break in messages that they need to resolve. Their listener will be called when a discontinuity event is triggered from the room lifecycle.
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.onDiscontinuity(bufferingPolicy: bufferingPolicy)
     }
 
     private func getBeforeSubscriptionStart(_ uuid: UUID, params: QueryOptions) async throws -> any PaginatedResult<Message> {

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -50,7 +50,7 @@ internal final class DefaultOccupancy: Occupancy, EmitsDiscontinuities {
     }
 
     // (CHA-O5) Users may subscribe to discontinuity events to know when there’s been a break in occupancy. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For occupancy, there shouldn’t need to be user action as most channels will send occupancy updates regularly as clients churn.
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.onDiscontinuity(bufferingPolicy: bufferingPolicy)
     }
 }

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -194,8 +194,8 @@ internal final class DefaultPresence: Presence, EmitsDiscontinuities {
     }
 
     // (CHA-PR8) Users may subscribe to discontinuity events to know when there’s been a break in presence. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For presence, there shouldn’t need to be user action as the underlying core SDK will heal the presence set.
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.onDiscontinuity(bufferingPolicy: bufferingPolicy)
     }
 
     private func decodePresenceData(from data: Any?) -> PresenceData? {

--- a/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
+++ b/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
@@ -18,7 +18,7 @@ internal actor DefaultRoomLifecycleContributor: RoomLifecycleContributor, EmitsD
         }
     }
 
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) -> Subscription<DiscontinuityEvent> {
         let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: bufferingPolicy)
         // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         discontinuitySubscriptions.append(subscription)

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -80,8 +80,8 @@ internal final class DefaultRoomReactions: RoomReactions, EmitsDiscontinuities {
     }
 
     // (CHA-ER5) Users may subscribe to discontinuity events to know when there’s been a break in reactions that they need to resolve. Their listener will be called when a discontinuity event is triggered from the room lifecycle.
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.onDiscontinuity(bufferingPolicy: bufferingPolicy)
     }
 
     private enum RoomReactionsError: Error {

--- a/Sources/AblyChat/DefaultTyping.swift
+++ b/Sources/AblyChat/DefaultTyping.swift
@@ -160,8 +160,8 @@ internal final class DefaultTyping: Typing {
     }
 
     // (CHA-T7) Users may subscribe to discontinuity events to know when there’s been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn’t need to be user action as the underlying core SDK will heal the presence set.
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        await featureChannel.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await featureChannel.onDiscontinuity(bufferingPolicy: bufferingPolicy)
     }
 
     private func processPresenceGet(members: [ARTPresenceMessage]?, error: ARTErrorInfo?) throws -> Set<String> {

--- a/Sources/AblyChat/EmitsDiscontinuities.swift
+++ b/Sources/AblyChat/EmitsDiscontinuities.swift
@@ -10,15 +10,15 @@ public struct DiscontinuityEvent: Sendable, Equatable {
 }
 
 public protocol EmitsDiscontinuities {
-    func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent>
-    /// Same as calling ``subscribeToDiscontinuities(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
+    func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent>
+    /// Same as calling ``onDiscontinuity(bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
     ///
     /// The `EmitsDiscontinuities` protocol provides a default implementation of this method.
-    func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent>
+    func onDiscontinuity() async -> Subscription<DiscontinuityEvent>
 }
 
 public extension EmitsDiscontinuities {
-    func subscribeToDiscontinuities() async -> Subscription<DiscontinuityEvent> {
-        await subscribeToDiscontinuities(bufferingPolicy: .unbounded)
+    func onDiscontinuity() async -> Subscription<DiscontinuityEvent> {
+        await onDiscontinuity(bufferingPolicy: .unbounded)
     }
 }

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -57,8 +57,8 @@ internal struct DefaultFeatureChannel: FeatureChannel {
     internal var contributor: DefaultRoomLifecycleContributor
     internal var roomLifecycleManager: RoomLifecycleManager
 
-    internal func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        await contributor.subscribeToDiscontinuities(bufferingPolicy: bufferingPolicy)
+    internal func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+        await contributor.onDiscontinuity(bufferingPolicy: bufferingPolicy)
     }
 
     internal func waitToBeAbleToPerformPresenceOperations(requestedByFeature requester: RoomFeature) async throws(ARTErrorInfo) {

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -71,7 +71,7 @@ struct DefaultMessagesTests {
 
     // @spec CHA-M7
     @Test
-    func subscribeToDiscontinuities() async throws {
+    func onDiscontinuity() async throws {
         // Given: A DefaultMessages instance
         let realtime = MockRealtime.create()
         let chatAPI = ChatAPI(realtime: realtime)
@@ -79,12 +79,12 @@ struct DefaultMessagesTests {
         let featureChannel = MockFeatureChannel(channel: channel)
         let messages = await DefaultMessages(featureChannel: featureChannel, chatAPI: chatAPI, roomID: "basketball", clientID: "clientId", logger: TestLogger())
 
-        // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
+        // When: The feature channel emits a discontinuity through `onDiscontinuity`
         let featureChannelDiscontinuity = DiscontinuityEvent(error: ARTErrorInfo.createUnknownError() /* arbitrary */ )
-        let messagesDiscontinuitySubscription = await messages.subscribeToDiscontinuities()
+        let messagesDiscontinuitySubscription = await messages.onDiscontinuity()
         await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
 
-        // Then: The DefaultMessages instance emits this discontinuity through `subscribeToDiscontinuities`
+        // Then: The DefaultMessages instance emits this discontinuity through `onDiscontinuity`
         let messagesDiscontinuity = try #require(await messagesDiscontinuitySubscription.first { _ in true })
         #expect(messagesDiscontinuity == featureChannelDiscontinuity)
     }

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -63,19 +63,19 @@ struct DefaultRoomReactionsTests {
 
     // @spec CHA-ER5
     @Test
-    func subscribeToDiscontinuities() async throws {
+    func onDiscontinuity() async throws {
         // all setup values here are arbitrary
         // Given: A DefaultRoomReactions instance
         let channel = MockRealtimeChannel()
         let featureChannel = MockFeatureChannel(channel: channel)
         let roomReactions = await DefaultRoomReactions(featureChannel: featureChannel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
 
-        // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
+        // When: The feature channel emits a discontinuity through `onDiscontinuity`
         let featureChannelDiscontinuity = DiscontinuityEvent(error: ARTErrorInfo.createUnknownError() /* arbitrary */ )
-        let messagesDiscontinuitySubscription = await roomReactions.subscribeToDiscontinuities()
+        let messagesDiscontinuitySubscription = await roomReactions.onDiscontinuity()
         await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
 
-        // Then: The DefaultRoomReactions instance emits this discontinuity through `subscribeToDiscontinuities`
+        // Then: The DefaultRoomReactions instance emits this discontinuity through `onDiscontinuity`
         let messagesDiscontinuity = try #require(await messagesDiscontinuitySubscription.first { _ in true })
         #expect(messagesDiscontinuity == featureChannelDiscontinuity)
     }

--- a/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
@@ -15,7 +15,7 @@ final actor MockFeatureChannel: FeatureChannel {
         resultOfWaitToBeAbleToPerformPresenceOperations = resultOfWaitToBeAblePerformPresenceOperations
     }
 
-    func subscribeToDiscontinuities(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
+    func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
         let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: bufferingPolicy)
         discontinuitySubscriptions.append(subscription)
         return subscription


### PR DESCRIPTION
I remember that when I wrote the public API in 20e7f5f, I was a bit reluctant to copy JS’s `on*` naming, because that read to me more like an API that was designed for receiving a listener (i.e. “_on_ this event, call this listener”). But, I think that after some back and forth with Andy, we decided to stick to the `on*` naming, hence `onStatusChange`. For some reason, though, I didn’t apply this decision to `subscribeToDiscontinuties`. So, do that.

Resolves #173.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated method names across various components for better clarity, changing `subscribeToDiscontinuities` to `onDiscontinuity`.
  
- **Bug Fixes**
	- Enhanced error handling in presence operations and typing events, ensuring more robust management of subscription events.

- **Documentation**
	- Updated comments and documentation to reflect the new method names and clarify functionality.

- **Tests**
	- Adjusted test cases to align with the renamed methods, ensuring continued verification of functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->