### PR TITLE
Rename `ResultOrder` enum to `OrderBy`

### DIFF
--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -30,7 +30,7 @@ public struct SendMessageParams: Sendable {
 }
 
 public struct QueryOptions: Sendable {
-    public enum ResultOrder: Sendable {
+    public enum OrderBy: Sendable {
         case oldestFirst
         case newestFirst
     }
@@ -38,12 +38,12 @@ public struct QueryOptions: Sendable {
     public var start: Date?
     public var end: Date?
     public var limit: Int?
-    public var orderBy: ResultOrder?
+    public var orderBy: OrderBy?
 
     // (CHA-M5g) The subscribers subscription point must be additionally specified (internally, by us) in the fromSerial query parameter.
     internal var fromSerial: String?
 
-    public init(start: Date? = nil, end: Date? = nil, limit: Int? = nil, orderBy: QueryOptions.ResultOrder? = nil) {
+    public init(start: Date? = nil, end: Date? = nil, limit: Int? = nil, orderBy: QueryOptions.OrderBy? = nil) {
         self.start = start
         self.end = end
         self.limit = limit


### PR DESCRIPTION
Per [CHADR-074](https://ably.atlassian.net/wiki/spaces/CHA/pages/3587866646/CHADR-074+History+direction+param+rename).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated terminology for message ordering, enhancing clarity in the user interface.
- **Bug Fixes**
	- Ensured consistency in the usage of message ordering across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->