### PR TITLE
Add no-arg variants of presence operations

### DIFF
--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -80,8 +80,11 @@ public protocol Presence: AnyObject, Sendable, EmitsDiscontinuities {
     func get(params: PresenceQuery) async throws -> [PresenceMember]
     func isUserPresent(clientID: String) async throws -> Bool
     func enter(data: PresenceData?) async throws
+    func enter() async throws
     func update(data: PresenceData?) async throws
+    func update() async throws
     func leave(data: PresenceData?) async throws
+    func leave() async throws
     func subscribe(event: PresenceEventType, bufferingPolicy: BufferingPolicy) async -> Subscription<PresenceEvent>
     /// Same as calling ``subscribe(event:bufferingPolicy:)`` with ``BufferingPolicy.unbounded``.
     ///
@@ -92,6 +95,20 @@ public protocol Presence: AnyObject, Sendable, EmitsDiscontinuities {
     ///
     /// The `Presence` protocol provides a default implementation of this method.
     func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent>
+}
+
+public extension Presence {
+    func enter() async throws {
+        try await enter(data: nil)
+    }
+
+    func update() async throws {
+        try await update(data: nil)
+    }
+
+    func leave() async throws {
+        try await leave(data: nil)
+    }
 }
 
 public extension Presence {


### PR DESCRIPTION
I missed these when copying across the public API from JS in 20e7f5f. The correct behaviour of these variants is not specified by the chat spec, but this will behaviour will do for now; I’ll think about it a bit more in #178.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new convenience methods for presence management: `enter()`, `update()`, and `leave()`.
  
- **Bug Fixes**
	- Enhanced compatibility of presence data by updating the `PresenceCustomData` enum to use `Int` instead of `NSNumber`.

- **Documentation**
	- Improved comments and documentation for clarity on presence data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->