### PR TITLE
Fix error code when fetching room with inconsistent options

### DIFF
--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -11,10 +11,8 @@ public let errorDomain = "AblyChatErrorDomain"
  The error codes for errors in the ``errorDomain`` error domain.
  */
 public enum ErrorCode: Int {
-    /// ``Rooms.get(roomID:options:)`` was called with a different set of room options than was used on a previous call. You must first release the existing room instance using ``Rooms.release(roomID:)``.
-    ///
-    /// TODO this code is a guess, revisit in https://github.com/ably-labs/ably-chat-swift/issues/32
-    case inconsistentRoomOptions = 1
+    /// The user attempted to perform an invalid action.
+    case badRequest = 40000
 
     case messagesAttachmentFailed = 102_001
     case presenceAttachmentFailed = 102_002
@@ -38,7 +36,7 @@ public enum ErrorCode: Int {
 
     /// Has a case for each of the ``ErrorCode`` cases that imply a fixed status code.
     internal enum CaseThatImpliesFixedStatusCode {
-        case inconsistentRoomOptions
+        case badRequest
         case messagesAttachmentFailed
         case presenceAttachmentFailed
         case reactionsAttachmentFailed
@@ -56,8 +54,8 @@ public enum ErrorCode: Int {
 
         internal var toNumericErrorCode: ErrorCode {
             switch self {
-            case .inconsistentRoomOptions:
-                .inconsistentRoomOptions
+            case .badRequest:
+                .badRequest
             case .messagesAttachmentFailed:
                 .messagesAttachmentFailed
             case .presenceAttachmentFailed:
@@ -93,7 +91,7 @@ public enum ErrorCode: Int {
         internal var statusCode: Int {
             // These status codes are taken from the "Chat-specific Error Codes" section of the spec.
             switch self {
-            case .inconsistentRoomOptions,
+            case .badRequest,
                  .roomInFailedState,
                  .roomIsReleasing,
                  .roomIsReleased,
@@ -175,7 +173,7 @@ internal enum ChatError {
     internal var codeAndStatusCode: ErrorCodeAndStatusCode {
         switch self {
         case .inconsistentRoomOptions:
-            .fixedStatusCode(.inconsistentRoomOptions)
+            .fixedStatusCode(.badRequest)
         case let .attachmentFailed(feature, _):
             switch feature {
             case .messages:

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -143,13 +143,13 @@ struct DefaultRoomsTests {
         _ = try await rooms.get(roomID: roomID, options: options)
 
         // When: get(roomID:options:) is called with the same ID but different options
-        // Then: It throws an inconsistentRoomOptions error
+        // Then: It throws a `badRequest` error
         let differentOptions = RoomOptions(presence: .init(subscribe: false))
 
         await #expect {
             try await rooms.get(roomID: roomID, options: differentOptions)
         } throws: { error in
-            isChatError(error, withCodeAndStatusCode: .fixedStatusCode(.inconsistentRoomOptions))
+            isChatError(error, withCodeAndStatusCode: .fixedStatusCode(.badRequest))
         }
     }
 
@@ -183,13 +183,13 @@ struct DefaultRoomsTests {
         _ = await operationWaitSubscription.first { $0.waitingOperationType == .get && $0.waitedOperationType == .release }
 
         // When: get(roomID:options:) is called with the same ID but different options
-        // Then: The second call to get(roomID:options:) throws an inconsistentRoomOptions error
+        // Then: The second call to get(roomID:options:) throws a `badRequest` error
         let differentOptions = RoomOptions(presence: .init(subscribe: false))
 
         await #expect {
             try await rooms.get(roomID: roomID, options: differentOptions)
         } throws: { error in
-            isChatError(error, withCodeAndStatusCode: .fixedStatusCode(.inconsistentRoomOptions))
+            isChatError(error, withCodeAndStatusCode: .fixedStatusCode(.badRequest))
         }
 
         // Post-test: Allow the CHA-RC1g release operation to complete


### PR DESCRIPTION
I should have done this in e7612c9.

The 40000 error code does not have a name in the spec or in the JS Chat SDK, so `nonspecificUserError` is my invention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling to categorize mismatched room options under a new error type, `nonspecificUserError`, instead of the previous `inconsistentRoomOptions`.

- **Tests**
	- Modified test cases to reflect the new error categorization for mismatched room options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->