### PR TITLE
Make `Rooms.release` non-throwing

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -32,7 +32,7 @@ actor MockRooms: Rooms {
         return room
     }
 
-    func release(roomID _: String) async throws {
+    func release(roomID _: String) async {
         fatalError("Not yet implemented")
     }
 

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -2,7 +2,7 @@ import Ably
 
 public protocol Rooms: AnyObject, Sendable {
     func get(roomID: String, options: RoomOptions) async throws -> any Room
-    func release(roomID: String) async throws
+    func release(roomID: String) async
     var clientOptions: ClientOptions { get }
 }
 
@@ -258,7 +258,7 @@ internal actor DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
         }
     #endif
 
-    internal func release(roomID: String) async throws {
+    internal func release(roomID: String) async {
         guard let roomState = roomStates[roomID] else {
             // CHA-RC1g2 (no-op)
             return

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -251,7 +251,7 @@ struct DefaultRoomsTests {
         // When: `release(roomID:)` is called with this room ID
         // Then: The call to `release(roomID:)` completes (this is as much as I can do to test the spec’s “no-op”; i.e. check it doesn’t seem to wait for anything or have any obvious side effects)
         let roomID = "basketball"
-        try await rooms.release(roomID: roomID)
+        await rooms.release(roomID: roomID)
     }
 
     // @spec CHA-RC1g3
@@ -290,7 +290,7 @@ struct DefaultRoomsTests {
         roomReleaseOperation.complete()
 
         // Then: The second call to `release(roomID:)` completes, and this second release call does not trigger a CHA-RL3 room release operation (i.e. in the language of the spec it reuses the “future” of the existing CHA-RC1g release operation)
-        try await secondReleaseResult
+        await secondReleaseResult
         #expect(await roomToReturn.releaseCallCount == 1)
     }
 
@@ -344,7 +344,7 @@ struct DefaultRoomsTests {
         roomReleaseOperation.complete()
 
         // Then: The second call to `release(roomID:)` completes, and this second release call does not trigger a CHA-RL3 room release operation (i.e. in the language of the spec it reuses the “future” of the existing CHA-RC1g release operation)
-        try await secondReleaseResult
+        await secondReleaseResult
         #expect(await roomToReturn.releaseCallCount == 1)
     }
 
@@ -371,7 +371,7 @@ struct DefaultRoomsTests {
         try #require(await rooms.testsOnly_hasRoomMapEntryWithID(roomID))
 
         // When: `release(roomID:)` is called with this room ID
-        _ = try await rooms.release(roomID: roomID)
+        _ = await rooms.release(roomID: roomID)
 
         // Then:
         // 1. first, the room is removed from the room map

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -281,7 +281,7 @@ struct IntegrationTests {
         // MARK: - Release
 
         // (1) Release the room
-        try await rxClient.rooms.release(roomID: roomID)
+        await rxClient.rooms.release(roomID: roomID)
 
         // (2) Check that we received a RELEASED status change as a result of releasing the room
         _ = try #require(await rxRoomStatusSubscription.first { $0.current == .released })


### PR DESCRIPTION
Mistake in 20e7f5f.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified error handling for the `release` method in chat functionality, now operating without throwing errors.
  
- **Bug Fixes**
	- Adjusted test cases to reflect the updated `release` method, ensuring correct functionality without error handling.

- **Tests**
	- Updated test implementations to remove `try` from `release` method calls, aligning with the new method signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->