### PR TITLE
[ECO-5003] Check that the library builds in `release` configuration

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -74,7 +74,7 @@ jobs:
       - id: generation-step
         run: swift run BuildTool generate-matrices >> $GITHUB_OUTPUT
 
-  check-spm:
+  build-and-test-spm:
     name: SPM (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-15
     needs: generate-matrices
@@ -94,7 +94,26 @@ jobs:
       - run: swift build -Xswiftc -warnings-as-errors
       - run: swift test -Xswiftc -warnings-as-errors
 
-  check-xcode:
+  build-release-configuration-spm:
+    name: SPM, `release` configuration (Xcode ${{ matrix.tooling.xcodeVersion }})
+    runs-on: macos-15
+    needs: generate-matrices
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.tooling.xcodeVersion }}
+
+      # https://forums.swift.org/t/warnings-as-errors-for-libraries-frameworks/58393/2
+      - run: swift build -Xswiftc -warnings-as-errors --configuration release
+
+  build-and-test-xcode:
     name: Xcode, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-15
     needs: generate-matrices
@@ -118,6 +137,26 @@ jobs:
 
       - name: Run tests
         run: swift run BuildTool test-library --platform ${{ matrix.platform }}
+
+  build-release-configuration-xcode:
+    name: Xcode, `release` configuration, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
+    runs-on: macos-15
+    needs: generate-matrices
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.tooling.xcodeVersion }}
+
+      - name: Build library
+        run: swift run BuildTool build-library --platform ${{ matrix.platform }} --configuration release
 
   check-example-app:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
@@ -149,8 +188,10 @@ jobs:
     needs:
       - lint
       - spec-coverage
-      - check-spm
-      - check-xcode
+      - build-and-test-spm
+      - build-release-configuration-spm
+      - build-and-test-xcode
+      - build-release-configuration-xcode
       - check-example-app
 
     steps:

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -8,6 +8,7 @@ import Table
 struct BuildTool: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         subcommands: [
+            BuildLibrary.self,
             BuildLibraryForTesting.self,
             TestLibrary.self,
             BuildExampleApp.self,
@@ -16,6 +17,23 @@ struct BuildTool: AsyncParsableCommand {
             SpecCoverage.self,
         ]
     )
+}
+
+@available(macOS 14, *)
+struct BuildLibrary: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Build the AblyChat library"
+    )
+
+    @Option var configuration: Configuration?
+    @Option var platform: Platform
+
+    mutating func run() async throws {
+        let destinationSpecifier = try await platform.resolve()
+        let scheme = "AblyChat"
+
+        try await XcodeRunner.runXcodebuild(action: "build", configuration: configuration, scheme: scheme, destination: destinationSpecifier)
+    }
 }
 
 @available(macOS 14, *)

--- a/Sources/BuildTool/Configuration.swift
+++ b/Sources/BuildTool/Configuration.swift
@@ -1,0 +1,12 @@
+import ArgumentParser
+
+enum Configuration: String, CaseIterable {
+    case debug
+    case release
+}
+
+extension Configuration: ExpressibleByArgument {
+    init?(argument: String) {
+        self.init(rawValue: argument)
+    }
+}

--- a/Sources/BuildTool/XcodeRunner.swift
+++ b/Sources/BuildTool/XcodeRunner.swift
@@ -2,11 +2,15 @@ import Foundation
 
 @available(macOS 14, *)
 enum XcodeRunner {
-    static func runXcodebuild(action: String?, scheme: String, destination: DestinationSpecifier) async throws {
+    static func runXcodebuild(action: String?, configuration: Configuration? = nil, scheme: String, destination: DestinationSpecifier) async throws {
         var arguments: [String] = []
 
         if let action {
             arguments.append(action)
+        }
+
+        if let configuration {
+            arguments.append(contentsOf: ["-configuration", configuration.rawValue])
         }
 
         arguments.append(contentsOf: ["-scheme", scheme])


### PR DESCRIPTION
To catch anything that's incorrectly gated behind an `#if DEBUG`, for example.

Resolves #68.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command for building the AblyChat library from the command line.
	- Added a configuration option for build processes, allowing users to select between debug and release modes.

- **Improvements**
	- Enhanced the GitHub Actions workflow for building and testing with clearer job names and added functionalities.

- **Bug Fixes**
	- Updated the build process to accommodate new configurations and ensure proper execution of tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->