### PR TITLE
Fix `JSONValue`’s interpretation of 0 and 1

### DIFF
--- a/Sources/AblyChat/JSONValue.swift
+++ b/Sources/AblyChat/JSONValue.swift
@@ -136,11 +136,15 @@ internal extension JSONValue {
             self = .array(array.map { .init(ablyCocoaPresenceData: $0) })
         case let string as String:
             self = .string(string)
-        // The order here is important, since a Bool can satisfy the NSNumber check
-        case let bool as Bool:
-            self = .bool(bool)
         case let number as NSNumber:
-            self = .number(number.doubleValue)
+            // We need to be careful to distinguish booleans from numbers of value 0 or 1; technique taken from https://forums.swift.org/t/jsonserialization-turns-bool-value-to-nsnumber/31909/3
+            if number === kCFBooleanTrue {
+                self = .bool(true)
+            } else if number === kCFBooleanFalse {
+                self = .bool(false)
+            } else {
+                self = .number(number.doubleValue)
+            }
         case is NSNull:
             self = .null
         default:

--- a/Tests/AblyChatTests/JSONValueTests.swift
+++ b/Tests/AblyChatTests/JSONValueTests.swift
@@ -13,6 +13,8 @@ struct JSONValueTests {
         // string
         (ablyCocoaPresenceData: "someString", expectedResult: "someString"),
         // number
+        (ablyCocoaPresenceData: NSNumber(value: 0), expectedResult: 0),
+        (ablyCocoaPresenceData: NSNumber(value: 1), expectedResult: 1),
         (ablyCocoaPresenceData: NSNumber(value: 123), expectedResult: 123),
         (ablyCocoaPresenceData: NSNumber(value: 123.456), expectedResult: 123.456),
         // bool
@@ -33,6 +35,8 @@ struct JSONValueTests {
           "someArray": [
             {
               "someStringKey": "someString",
+              "zero": 0,
+              "one": 1,
               "someIntegerKey": 123,
               "someFloatKey": 123.456,
               "someTrueKey": true,
@@ -53,6 +57,8 @@ struct JSONValueTests {
             "someArray": [
                 [
                     "someStringKey": "someString",
+                    "zero": 0,
+                    "one": 1,
                     "someIntegerKey": 123,
                     "someFloatKey": 123.456,
                     "someTrueKey": true,
@@ -79,6 +85,8 @@ struct JSONValueTests {
         // string
         (value: "someString", expectedResult: "someString"),
         // number
+        (value: 0, expectedResult: NSNumber(value: 0)),
+        (value: 1, expectedResult: NSNumber(value: 1)),
         (value: 123, expectedResult: NSNumber(value: 123)),
         (value: 123.456, expectedResult: NSNumber(value: 123.456)),
         // bool
@@ -100,6 +108,8 @@ struct JSONValueTests {
             "someArray": [
                 [
                     "someStringKey": "someString",
+                    "zero": 0,
+                    "one": 1,
                     "someIntegerKey": 123,
                     "someFloatKey": 123.456,
                     "someTrueKey": true,
@@ -120,6 +130,8 @@ struct JSONValueTests {
               "someStringKey": "someString",
               "someIntegerKey": 123,
               "someFloatKey": 123.456,
+              "zero": 0,
+              "one": 1,
               "someTrueKey": true,
               "someFalseKey": false,
               "someNullKey": null


### PR DESCRIPTION
It was incorrectly interpreting them as booleans. Mistake in 80e8585.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type handling for boolean and numeric values in the JSONValue enum.
	- Added support for specific numeric test cases in the test suite.
  
- **Bug Fixes**
	- Improved accuracy in distinguishing between boolean and numeric types during initialization.

- **Tests**
	- Expanded test coverage for numeric conversions, ensuring correct handling of NSNumber instances representing integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->