### PR TITLE
[ECO-5035] Remove usage of `Decodable` for decoding data recieved from Realtime

### DIFF
--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -3,7 +3,7 @@ import Ably
 /**
  * Chat Message Actions.
  */
-public enum MessageAction: String, Codable, Sendable {
+public enum MessageAction: String, Sendable {
     /**
      * Action applied to a new message.
      */

--- a/Sources/AblyChat/Headers.swift
+++ b/Sources/AblyChat/Headers.swift
@@ -1,8 +1,8 @@
 // TODO: https://github.com/ably-labs/ably-chat-swift/issues/13 - try to improve this type
 
-public enum HeadersValue: Sendable, Codable, Equatable {
+public enum HeadersValue: Sendable, Equatable {
     case string(String)
-    case number(Double) // Changed from NSNumber to Double to conform to Codable. Address in linked issue above.
+    case number(Double)
     case bool(Bool)
     case null
 }

--- a/Sources/AblyChat/JSONCodable.swift
+++ b/Sources/AblyChat/JSONCodable.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 internal protocol JSONEncodable {
     var toJSONValue: JSONValue { get }
 }
@@ -27,6 +29,7 @@ internal enum JSONValueDecodingError: Error {
     case valueIsNotObject
     case noValueForKey(String)
     case wrongTypeForKey(String, actualValue: JSONValue)
+    case failedToDecodeFromRawValue(String)
 }
 
 // Default implementation of `JSONDecodable` conformance for `JSONObjectDecodable`
@@ -42,7 +45,7 @@ internal extension JSONObjectDecodable {
 
 internal typealias JSONObjectCodable = JSONObjectDecodable & JSONObjectEncodable
 
-// MARK: - Extracting values from a dictionary
+// MARK: - Extracting primitive values from a dictionary
 
 /// This extension adds some helper methods for extracting values from a dictionary of `JSONValue` values; you may find them helpful when implementing `JSONCodable`.
 internal extension [String: JSONValue] {
@@ -226,5 +229,72 @@ internal extension [String: JSONValue] {
         }
 
         return boolValue
+    }
+}
+
+// MARK: - Extracting dates from a dictionary
+
+internal extension [String: JSONValue] {
+    /// If this dictionary contains a value for `key`, and this value has case `number`, this returns a date created by interpreting this value as the number of milliseconds since the Unix epoch (which is the format used by Ably).
+    ///
+    /// - Throws:
+    ///   - `JSONValueDecodingError.noValueForKey` if the key is absent
+    ///   - `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `number`
+    func ablyProtocolDateValueForKey(_ key: String) throws -> Date {
+        let millisecondsSinceEpoch = try numberValueForKey(key)
+
+        return dateFromMillisecondsSinceEpoch(millisecondsSinceEpoch)
+    }
+
+    /// If this dictionary contains a value for `key`, and this value has case `number`, this returns a date created by interpreting this value as the number of milliseconds since the Unix epoch (which is the format used by Ably). If this dictionary does not contain a value for `key`, or if the value for `key` has case `null`, it returns `nil`.
+    ///
+    /// - Throws: `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `number` or `null`
+    func optionalAblyProtocolDateValueForKey(_ key: String) throws -> Date? {
+        guard let millisecondsSinceEpoch = try optionalNumberValueForKey(key) else {
+            return nil
+        }
+
+        return dateFromMillisecondsSinceEpoch(millisecondsSinceEpoch)
+    }
+
+    private func dateFromMillisecondsSinceEpoch(_ millisecondsSinceEpoch: Double) -> Date {
+        .init(timeIntervalSince1970: millisecondsSinceEpoch / 1000)
+    }
+}
+
+// MARK: - Extracting RawRepresentable values from a dictionary
+
+internal extension [String: JSONValue] {
+    /// If this dictionary contains a value for `key`, and this value has case `string`, this creates an instance of `T` using its `init(rawValue:)` initializer.
+    ///
+    /// - Throws:
+    ///   - `JSONValueDecodingError.noValueForKey` if the key is absent
+    ///   - `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `string`
+    ///   - `JSONValueDecodingError.failedToDecodeFromRawValue` if `init(rawValue:)` returns `nil`
+    func rawRepresentableValueForKey<T: RawRepresentable>(_ key: String, type: T.Type = T.self) throws -> T where T.RawValue == String {
+        let rawValue = try stringValueForKey(key)
+
+        return try rawRepresentableValueFromRawValue(rawValue, type: T.self)
+    }
+
+    /// If this dictionary contains a value for `key`, and this value has case `string`, this creates an instance of `T` using its `init(rawValue:)` initializer. If this dictionary does not contain a value for `key`, or if the value for `key` has case `null`, it returns `nil`.
+    ///
+    /// - Throws:
+    ///   - `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `string` or `null`
+    ///   - `JSONValueDecodingError.failedToDecodeFromRawValue` if `init(rawValue:)` returns `nil`
+    func optionalRawRepresentableValueForKey<T: RawRepresentable>(_ key: String, type: T.Type = T.self) throws -> T? where T.RawValue == String {
+        guard let rawValue = try optionalStringValueForKey(key) else {
+            return nil
+        }
+
+        return try rawRepresentableValueFromRawValue(rawValue, type: T.self)
+    }
+
+    private func rawRepresentableValueFromRawValue<T: RawRepresentable>(_ rawValue: String, type _: T.Type = T.self) throws -> T where T.RawValue == String {
+        guard let value = T(rawValue: rawValue) else {
+            throw JSONValueDecodingError.failedToDecodeFromRawValue(rawValue)
+        }
+
+        return value
     }
 }

--- a/Sources/AblyChat/JSONCodable.swift
+++ b/Sources/AblyChat/JSONCodable.swift
@@ -63,7 +63,7 @@ internal extension [String: JSONValue] {
         return objectValue
     }
 
-    /// If this dictionary contains a value for `key`, and this value has case `object`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for key has case `null`, it returns `nil`.
+    /// If this dictionary contains a value for `key`, and this value has case `object`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for `key` has case `null`, it returns `nil`.
     ///
     /// - Throws: `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `object` or `null`
     func optionalObjectValueForKey(_ key: String) throws -> [String: JSONValue]? {
@@ -99,7 +99,7 @@ internal extension [String: JSONValue] {
         return arrayValue
     }
 
-    /// If this dictionary contains a value for `key`, and this value has case `array`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for key has case `null`, it returns `nil`.
+    /// If this dictionary contains a value for `key`, and this value has case `array`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for `key` has case `null`, it returns `nil`.
     ///
     /// - Throws: `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `array` or `null`
     func optionalArrayValueForKey(_ key: String) throws -> [JSONValue]? {
@@ -135,7 +135,7 @@ internal extension [String: JSONValue] {
         return stringValue
     }
 
-    /// If this dictionary contains a value for `key`, and this value has case `string`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for key has case `null`, it returns `nil`.
+    /// If this dictionary contains a value for `key`, and this value has case `string`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for `key` has case `null`, it returns `nil`.
     ///
     /// - Throws: `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `string` or `null`
     func optionalStringValueForKey(_ key: String) throws -> String? {
@@ -171,7 +171,7 @@ internal extension [String: JSONValue] {
         return numberValue
     }
 
-    /// If this dictionary contains a value for `key`, and this value has case `number`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for key has case `null`, it returns `nil`.
+    /// If this dictionary contains a value for `key`, and this value has case `number`, this returns the associated value. If this dictionary does not contain a value for `key`, or if the value for `key` has case `null`, it returns `nil`.
     ///
     /// - Throws: `JSONValueDecodingError.wrongTypeForKey` if the value does not have case `number` or `null`
     func optionalNumberValueForKey(_ key: String) throws -> Double? {

--- a/Sources/AblyChat/JSONValue.swift
+++ b/Sources/AblyChat/JSONValue.swift
@@ -136,6 +136,7 @@ internal extension JSONValue {
     /// - a non-`nil` value of `ARTPresenceMessage`’s `data` property
     /// - a non-`nil` value of `ARTMessage`’s `data` property
     /// - the return value of the `toJSON()` method of a non-`nil` value of `ARTMessage`’s `extras` property
+    /// - an element of `ARTHTTPPaginatedResult`’s `items` array
     init(ablyCocoaData: Any) {
         switch ablyCocoaData {
         case let dictionary as [String: Any]:

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -13,7 +13,7 @@ public typealias MessageMetadata = Metadata
 /**
  * Represents a single message in a chat room.
  */
-public struct Message: Sendable, Codable, Identifiable, Equatable {
+public struct Message: Sendable, Identifiable, Equatable {
     // id to meet Identifiable conformance. 2 messages in the same channel cannot have the same serial.
     public var id: String { serial }
 
@@ -87,15 +87,19 @@ public struct Message: Sendable, Codable, Identifiable, Equatable {
         self.metadata = metadata
         self.headers = headers
     }
+}
 
-    internal enum CodingKeys: String, CodingKey {
-        case serial
-        case action
-        case clientID = "clientId"
-        case roomID = "roomId"
-        case text
-        case createdAt
-        case metadata
-        case headers
+extension Message: JSONObjectDecodable {
+    internal init(jsonObject: [String: JSONValue]) throws {
+        try self.init(
+            serial: jsonObject.stringValueForKey("serial"),
+            action: jsonObject.rawRepresentableValueForKey("action"),
+            clientID: jsonObject.stringValueForKey("clientId"),
+            roomID: jsonObject.stringValueForKey("roomId"),
+            text: jsonObject.stringValueForKey("text"),
+            createdAt: jsonObject.optionalAblyProtocolDateValueForKey("createdAt"),
+            metadata: jsonObject.objectValueForKey("metadata").mapValues { try .init(jsonValue: $0) },
+            headers: jsonObject.objectValueForKey("headers").mapValues { try .init(jsonValue: $0) }
+        )
     }
 }

--- a/Sources/AblyChat/Metadata.swift
+++ b/Sources/AblyChat/Metadata.swift
@@ -1,7 +1,6 @@
 // TODO: https://github.com/ably-labs/ably-chat-swift/issues/13 - try to improve this type
-// I attempted to address this issue by making a struct conforming to Codable which would at least give us some safety in knowing items can be encoded and decoded. Gave up on it due to fixing other protocol requirements so gone for the same approach as Headers for now, we can investigate whether we need to be open to more types than this later.
 
-public enum MetadataValue: Sendable, Codable, Equatable {
+public enum MetadataValue: Sendable, Equatable {
     case string(String)
     case number(Double)
     case bool(Bool)

--- a/Sources/AblyChat/Occupancy.swift
+++ b/Sources/AblyChat/Occupancy.swift
@@ -48,7 +48,7 @@ public extension Occupancy {
 /**
  * Represents the occupancy of a chat room.
  */
-public struct OccupancyEvent: Sendable, Encodable, Decodable {
+public struct OccupancyEvent: Sendable {
     /**
      * The number of connections to the chat room.
      */
@@ -62,5 +62,14 @@ public struct OccupancyEvent: Sendable, Encodable, Decodable {
     public init(connections: Int, presenceMembers: Int) {
         self.connections = connections
         self.presenceMembers = presenceMembers
+    }
+}
+
+extension OccupancyEvent: JSONObjectDecodable {
+    internal init(jsonObject: [String: JSONValue]) throws {
+        try self.init(
+            connections: Int(jsonObject.numberValueForKey("connections")),
+            presenceMembers: Int(jsonObject.numberValueForKey("presenceMembers"))
+        )
     }
 }


### PR DESCRIPTION
Switch to using `JSONDecodable` internally. This allows us to avoid the dance of encoding an ably-cocoa object to a `Data` just so that we can decode it using `JSONDecoder`. It also gives us consistency in how we handle data objects received from ably-cocoa.

This means that we now have to write a bit more code in order to decode objects manually, but I think we can live with it. (It might also be that we can revisit in the future and either automatically generate the `JSONDecodable` conformance using macros, or that we can find some other, better way of bridging with the compiler’s synthesised `Decodable` conformance.)

Resolves #84.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON handling capabilities with new protocols for encoding and decoding.
	- Custom initializers for various structs and enums to improve JSON object handling.

- **Bug Fixes**
	- Improved error handling in JSON decoding processes.

- **Documentation**
	- Updated comments for clarity in JSON extraction methods.

- **Refactor**
	- Removed automatic Codable conformance from several entities to implement a more manual JSON handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->