### PR TITLE
Change the type of `LogContext`

### DIFF
--- a/Sources/AblyChat/Logging.swift
+++ b/Sources/AblyChat/Logging.swift
@@ -1,6 +1,6 @@
 import os
 
-public typealias LogContext = [String: any Sendable]
+public typealias LogContext = [String: JSONValue]
 
 public protocol LogHandler: AnyObject, Sendable {
     /**


### PR DESCRIPTION
We don’t actually emit any context at the moment, I believe, nor do we tell users what they’re meant to do with it. But, still, before our first release of the public API, let’s use a type that the user can at least easily pass through to a logging backend.

We still have #8 for figuring out what this context is actually meant to be used for.