### PR TITLE
[ECO-4963] Clean up when user finishes with subscription

### DIFF
--- a/Example/AblyChatExample/Mocks/MockSubscription.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscription.swift
@@ -27,4 +27,10 @@ final class MockSubscription<T: Sendable>: Sendable, AsyncSequence {
             randomElement()
         })
     }
+
+    func setOnTermination(_ onTermination: @escaping @Sendable () -> Void) {
+        continuation.onTermination = { _ in
+            onTermination()
+        }
+    }
 }

--- a/Example/AblyChatExample/Mocks/MockSubscription.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscription.swift
@@ -2,7 +2,7 @@ import Ably
 import AblyChat
 import AsyncAlgorithms
 
-struct MockSubscription<T: Sendable>: Sendable, AsyncSequence {
+final class MockSubscription<T: Sendable>: Sendable, AsyncSequence {
     typealias Element = T
     typealias AsyncTimerMockSequence = AsyncMapSequence<AsyncTimerSequence<ContinuousClock>, Element>
     typealias MockMergedSequence = AsyncMerge2Sequence<AsyncStream<Element>, AsyncTimerMockSequence>

--- a/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// This is copied from ably-chat’s internal class `SubscriptionStorage`.
+class MockSubscriptionStorage<Element: Sendable>: @unchecked Sendable {
+    // We hold a weak reference to the subscriptions that we create, so that the subscriptions’ termination handlers get called when the user releases their final reference to the subscription.
+    private struct WeaklyHeldSubscription {
+        weak var subscription: MockSubscription<Element>?
+    }
+
+    /// Access must be synchronised via ``lock``.
+    private var subscriptions: [UUID: WeaklyHeldSubscription] = [:]
+    private let lock = NSLock()
+
+    // You must not call the `setOnTermination` method of a subscription returned by this function, as it will replace the termination handler set by this function.
+    func create(randomElement: @escaping @Sendable () -> Element, interval: Double) -> MockSubscription<Element> {
+        let subscription = MockSubscription<Element>(randomElement: randomElement, interval: interval)
+        let id = UUID()
+
+        lock.lock()
+        subscriptions[id] = .init(subscription: subscription)
+        lock.unlock()
+
+        subscription.setOnTermination { [weak self] in
+            self?.subscriptionDidTerminate(id: id)
+        }
+
+        return subscription
+    }
+
+    private func subscriptionDidTerminate(id: UUID) {
+        lock.lock()
+        subscriptions.removeValue(forKey: id)
+        lock.unlock()
+    }
+
+    func emit(_ element: Element) {
+        for subscription in subscriptions.values {
+            subscription.subscription?.emit(element)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ Taking messages as an example, you can listen for discontinuities like so:
 
 ```swift
 let subscription = room.messages.onDiscontinuity()
-for await error in subscription {
-    print("Recovering from the error: \(error)")
+for await discontinuityEvent in subscription {
+    print("Recovering from the error: \(discontinuityEvent.error)")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,19 +103,13 @@ let error = await chatClient.connection.error
 
 ### Subscribing to connection status changes
 
-You can subscribe to connection status changes by registering a listener, like so:
+To subscribe to connection status changes, create a subscription with the `onStatusChange` method. You can then iterate over it using its `AsyncSequence` interface:
 
 ```swift
 let subscription = chatClient.connection.onStatusChange()
 for await statusChange in subscription {
     print("Connection status changed to: \(statusChange.current)")
 }
-```
-
-To stop listening to changes, call the `unsubscribe` method on the returned subscription instance:
-
-```swift
-subscription.unsubscribe()
 ```
 
 ## Chat rooms
@@ -209,7 +203,7 @@ switch await room.status {
 
 ### Listening to room status updates
 
-You can also subscribe to changes in the room status and be notified whenever they happen by registering a listener:
+You can also subscribe to changes in the room status and be notified whenever they happen by creating a subscription using the room’s `onStatusChange` method and then iterating over this subscription using its `AsyncSequence` interface:
 
 ```swift
 let statusSubscription = try await room.onStatusChange()
@@ -218,19 +212,13 @@ for await status in statusSubscription {
 }
 ```
 
-To stop listening to room status changes, call the `unsubscribe` method on the returned subscription instance:
-
-```swift
-statusSubscription.unsubscribe()
-```
-
 ## Handling discontinuity
 
 There may be instances where the connection to Ably is lost for a period of time, for example, when the user enters a tunnel. In many
 circumstances, the connection will recover and operation will continue with no discontinuity of messages. However, during extended
 periods of disconnection, continuity cannot be guaranteed and you'll need to take steps to recover messages you might have missed.
 
-Each feature of the Chat SDK provides an `onDiscontinuity` method. Here you can register a listener that will be notified whenever a
+Each feature of the Chat SDK provides an `onDiscontinuity` method. Here you can create a subscription that will emit a discontinuity event on its `AsyncSequence` interface whenever a
 discontinuity in that feature has been observed.
 
 Taking messages as an example, you can listen for discontinuities like so:
@@ -241,8 +229,6 @@ for await discontinuityEvent in subscription {
     print("Recovering from the error: \(discontinuityEvent.error)")
 }
 ```
-
-To stop listening to discontinuities, call `unsubscribe` method on returned subscription instance.
 
 ## Chat messages
 
@@ -256,8 +242,6 @@ for await message in messagesSubscription {
     print("Message received: \(message)")
 }
 ```
-
-To stop listening for the new messages, call the `unsubscribe` method on the returned subscription instance.
 
 ### Sending messages
 
@@ -286,8 +270,8 @@ if paginatedResult.hasNext {
 
 ### Retrieving message history for a subscribed listener
 
-In addition to being able to unsubscribe from messages, the return value from `messages.subscribe` also includes the `getPreviousMessages`
-method. It can be used to request historical messages in the chat room that were sent up to the point that a particular listener was subscribed. It returns a
+The return value from `messages.subscribe` includes the `getPreviousMessages`
+method, which can be used to request historical messages in the chat room that were sent up to the point that a particular listener was subscribed. It returns a
 paginated response that can be used to request for more messages:
 
 ```swift
@@ -349,7 +333,7 @@ try await room.presence.leave(data: ["status": "Bye!"])
 
 ### Subscribing to presence updates
 
-You can provide a single listener for all presence event types:
+You can create a single subscription for all presence event types:
 
 ```swift
 let presenceSubscription = try await room.presence.subscribe(events: [.enter, .leave, .update])
@@ -357,8 +341,6 @@ for await event in presenceSubscription {
     print("Presence event `\(event.action)` from `\(event.clientId)` with data `\(event.data)`")
 }
 ```
-
-To stop listening for the presence updates, call the `unsubscribe` method on the returned subscription instance.
 
 ## Typing indicators
 
@@ -401,7 +383,7 @@ try await room.typing.stop()
 
 ### Subscribing to typing updates
 
-To subscribe to typing events, create a subscription with the `subscribe` method:
+To subscribe to typing events, create a subscription with the `subscribe` method. You can then iterate over it using its `AsyncSequence` interface:
 
 ```swift
 let typingSubscription = try await room.typing.subscribe()
@@ -410,15 +392,13 @@ for await typing in typingSubscription {
 }
 ```
 
-To stop listening for the typing events, call the `unsubscribe` method on the returned subscription instance.
-
 ## Occupancy of a chat room
 
 Occupancy tells you how many users are connected to the chat room.
 
 ### Subscribing to occupancy updates
 
-To subscribe to occupancy updates, subscribe a listener to the chat room `occupancy` member:
+To subscribe to occupancy updates, create a subscription by calling the `subscribe` method on the chat room’s `occupancy` member. You can then iterate over it using its `AsyncSequence` interface:
 
 ```swift
 let occupancySubscription = try await room.occupancy.subscribe()
@@ -426,8 +406,6 @@ for await event in occupancySubscription {
     occupancyInfo = "Connections: \(event.presenceMembers) (\(event.connections))"
 }
 ```
-
-To stop listening for the typing events, call the `unsubscribe` method on the returned subscription instance.
 
 Occupancy updates are delivered in near-real-time, with updates in quick succession batched together for performance.
 
@@ -468,8 +446,6 @@ for await reaction in reactionSubscription {
     print("Received a reaction of type \(reaction.type), and metadata \(reaction.metadata)")
 }
 ```
-
-To stop receiving reactions, call the `unsubscribe` method on the returned subscription instance.
 
 ## Example app
 

--- a/Sources/AblyChat/DefaultConnection.swift
+++ b/Sources/AblyChat/DefaultConnection.swift
@@ -30,7 +30,7 @@ internal final class DefaultConnection: Connection {
         let subscription = Subscription<ConnectionStatusChange>(bufferingPolicy: bufferingPolicy)
 
         // (CHA-CS5) The chat client must monitor the underlying realtime connection for connection status changes.
-        realtime.connection.on { [weak self] stateChange in
+        let eventListener = realtime.connection.on { [weak self] stateChange in
             guard let self else {
                 return
             }
@@ -93,6 +93,10 @@ internal final class DefaultConnection: Connection {
                 await connectionStatusManager.updateError(to: stateChange.reason)
                 await connectionStatusManager.updateStatus(to: currentState)
             }
+        }
+
+        subscription.addTerminationHandler { [weak self] in
+            self?.realtime.connection.off(eventListener)
         }
 
         return subscription

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -40,7 +40,7 @@ internal final class DefaultRoomReactions: RoomReactions, EmitsDiscontinuities {
         let subscription = Subscription<Reaction>(bufferingPolicy: bufferingPolicy)
 
         // (CHA-ER4c) Realtime events with an unknown name shall be silently discarded.
-        channel.subscribe(RoomReactionEvents.reaction.rawValue) { [clientID, logger] message in
+        let eventListener = channel.subscribe(RoomReactionEvents.reaction.rawValue) { [clientID, logger] message in
             logger.log(message: "Received roomReaction message: \(message)", level: .debug)
             Task {
                 do {
@@ -80,6 +80,10 @@ internal final class DefaultRoomReactions: RoomReactions, EmitsDiscontinuities {
                     logger.log(message: "Error processing incoming reaction message: \(error)", level: .error)
                 }
             }
+        }
+
+        subscription.addTerminationHandler { [weak self] in
+            self?.channel.unsubscribe(eventListener)
         }
 
         return subscription

--- a/Sources/AblyChat/DefaultTyping.swift
+++ b/Sources/AblyChat/DefaultTyping.swift
@@ -25,7 +25,7 @@ internal final class DefaultTyping: Typing {
         let subscription = Subscription<TypingEvent>(bufferingPolicy: bufferingPolicy)
         let eventTracker = EventTracker()
 
-        channel.presence.subscribe { [weak self] message in
+        let eventListener = channel.presence.subscribe { [weak self] message in
             guard let self else {
                 return
             }
@@ -72,6 +72,13 @@ internal final class DefaultTyping: Typing {
                 logger.log(message: "Failed to fetch presence set after \(maxRetryDuration) seconds. Giving up.", level: .error)
             }
         }
+
+        subscription.addTerminationHandler { [weak self] in
+            if let eventListener {
+                self?.channel.presence.unsubscribe(eventListener)
+            }
+        }
+
         return subscription
     }
 

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -192,10 +192,10 @@ internal extension QueryOptions {
 }
 
 // Currently a copy-and-paste of `Subscription`; see notes on that one. For `MessageSubscription`, my intention is that the `BufferingPolicy` passed to `subscribe(bufferingPolicy:)` will also define what the `MessageSubscription` does with messages that are received _before_ the user starts iterating over the sequence (this buffering will allow us to implement the requirement that there be no discontinuity between the the last message returned by `getPreviousMessages` and the first element you get when you iterate).
-public struct MessageSubscription: Sendable, AsyncSequence {
+public final class MessageSubscription: Sendable, AsyncSequence {
     public typealias Element = Message
 
-    private var subscription: Subscription<Element>
+    private let subscription: Subscription<Element>
 
     // can be set by either initialiser
     private let getPreviousMessages: @Sendable (QueryOptions) async throws -> any PaginatedResult<Message>

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -192,6 +192,10 @@ internal extension QueryOptions {
 }
 
 // Currently a copy-and-paste of `Subscription`; see notes on that one. For `MessageSubscription`, my intention is that the `BufferingPolicy` passed to `subscribe(bufferingPolicy:)` will also define what the `MessageSubscription` does with messages that are received _before_ the user starts iterating over the sequence (this buffering will allow us to implement the requirement that there be no discontinuity between the the last message returned by `getPreviousMessages` and the first element you get when you iterate).
+
+/// A non-throwing `AsyncSequence` whose element is ``Message``. The Chat SDK uses this type as the return value of the ``Messages`` methods that allow you to find out about received chat messages.
+///
+/// You should only iterate over a given `MessageSubscription` once; the results of iterating more than once are undefined.
 public final class MessageSubscription: Sendable, AsyncSequence {
     public typealias Element = Message
 
@@ -217,6 +221,10 @@ public final class MessageSubscription: Sendable, AsyncSequence {
 
     internal func emit(_ element: Element) {
         subscription.emit(element)
+    }
+
+    internal func addTerminationHandler(_ onTermination: @escaping (@Sendable () -> Void)) {
+        subscription.addTerminationHandler(onTermination)
     }
 
     public func getPreviousMessages(params: QueryOptions) async throws -> any PaginatedResult<Message> {

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -87,8 +87,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
     /// Manager state that relates to individual contributors, keyed by contributors’ ``Contributor/id``. Stored separately from ``contributors`` so that the latter can be a `let`, to make it clear that the contributors remain fixed for the lifetime of the manager.
     private var contributorAnnotations: ContributorAnnotations
     private var listenForStateChangesTask: Task<Void, Never>!
-    // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
-    private var roomStatusChangeSubscriptions: [Subscription<RoomStatusChange>] = []
+    private var roomStatusChangeSubscriptions = SubscriptionStorage<RoomStatusChange>()
     private var operationResultContinuations = OperationResultContinuations()
 
     // MARK: - Initializers and `deinit`
@@ -330,15 +329,12 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
     }
 
     internal func onRoomStatusChange(bufferingPolicy: BufferingPolicy) -> Subscription<RoomStatusChange> {
-        let subscription: Subscription<RoomStatusChange> = .init(bufferingPolicy: bufferingPolicy)
-        roomStatusChangeSubscriptions.append(subscription)
-        return subscription
+        roomStatusChangeSubscriptions.create(bufferingPolicy: bufferingPolicy)
     }
 
     #if DEBUG
-        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         /// Supports the ``testsOnly_onRoomStatusChange()`` method.
-        private var statusChangeSubscriptions: [Subscription<StatusChange>] = []
+        private var statusChangeSubscriptions = SubscriptionStorage<StatusChange>()
 
         internal struct StatusChange {
             internal var current: Status
@@ -347,15 +343,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
 
         /// Allows tests to subscribe to changes to the manager’s internal status (which exposes more cases and additional metadata, compared to the ``RoomStatus`` exposed by ``onRoomStatusChange(bufferingPolicy:)``).
         internal func testsOnly_onStatusChange() -> Subscription<StatusChange> {
-            let subscription: Subscription<StatusChange> = .init(bufferingPolicy: .unbounded)
-            statusChangeSubscriptions.append(subscription)
-            return subscription
-        }
-
-        internal func emitStatusChange(_ change: StatusChange) {
-            for subscription in statusChangeSubscriptions {
-                subscription.emit(change)
-            }
+            statusChangeSubscriptions.create(bufferingPolicy: .unbounded)
         }
     #endif
 
@@ -368,27 +356,20 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
         // Avoid a double-emit of room status when changing between `Status` values that map to the same `RoomStatus`; e.g. when changing from `.suspendedAwaitingStartOfRetryOperation` to `.suspended`.
         if new.toRoomStatus != previous.toRoomStatus {
             let statusChange = RoomStatusChange(current: status.toRoomStatus, previous: previous.toRoomStatus)
-            emitRoomStatusChange(statusChange)
+            roomStatusChangeSubscriptions.emit(statusChange)
         }
 
         #if DEBUG
             let statusChange = StatusChange(current: status, previous: previous)
-            emitStatusChange(statusChange)
+            statusChangeSubscriptions.emit(statusChange)
         #endif
-    }
-
-    private func emitRoomStatusChange(_ change: RoomStatusChange) {
-        for subscription in roomStatusChangeSubscriptions {
-            subscription.emit(change)
-        }
     }
 
     // MARK: - Handling contributor state changes
 
     #if DEBUG
-        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         /// Supports the ``testsOnly_subscribeToHandledContributorStateChanges()`` method.
-        private var stateChangeHandledSubscriptions: [Subscription<ARTChannelStateChange>] = []
+        private var stateChangeHandledSubscriptions = SubscriptionStorage<ARTChannelStateChange>()
 
         /// Returns a subscription which emits the contributor state changes that have been handled by the manager.
         ///
@@ -401,9 +382,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
         /// - the manager has recorded all transient disconnect timeouts provoked by the state change (you can retrieve this information using ``testsOnly_hasTransientDisconnectTimeout(for:) or ``testsOnly_idOfTransientDisconnectTimeout(for:)``)
         /// - the manager has performed all transient disconnect timeout cancellations provoked by the state change (you can retrieve this information using ``testsOnly_hasTransientDisconnectTimeout(for:) or ``testsOnly_idOfTransientDisconnectTimeout(for:)``)
         internal func testsOnly_subscribeToHandledContributorStateChanges() -> Subscription<ARTChannelStateChange> {
-            let subscription = Subscription<ARTChannelStateChange>(bufferingPolicy: .unbounded)
-            stateChangeHandledSubscriptions.append(subscription)
-            return subscription
+            stateChangeHandledSubscriptions.create(bufferingPolicy: .unbounded)
         }
 
         internal func testsOnly_pendingDiscontinuityEvent(for contributor: Contributor) -> DiscontinuityEvent? {
@@ -422,9 +401,8 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
             contributorAnnotations[contributor].transientDisconnectTimeout?.id
         }
 
-        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         /// Supports the ``testsOnly_subscribeToHandledTransientDisconnectTimeouts()`` method.
-        private var transientDisconnectTimeoutHandledSubscriptions: [Subscription<UUID>] = []
+        private var transientDisconnectTimeoutHandledSubscriptions = SubscriptionStorage<UUID>()
 
         /// Returns a subscription which emits the IDs of the transient disconnect timeouts that have been handled by the manager.
         ///
@@ -432,9 +410,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
         ///
         /// - the manager has performed all status changes provoked by the completion of this timeout (which may be none, if the timeout gets cancelled)
         internal func testsOnly_subscribeToHandledTransientDisconnectTimeouts() -> Subscription<UUID> {
-            let subscription = Subscription<UUID>(bufferingPolicy: .unbounded)
-            transientDisconnectTimeoutHandledSubscriptions.append(subscription)
-            return subscription
+            transientDisconnectTimeoutHandledSubscriptions.create(bufferingPolicy: .unbounded)
         }
     #endif
 
@@ -560,18 +536,14 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
 
         #if DEBUG
             logger.log(message: "Emitting state change handled event for \(stateChange)", level: .debug)
-            for subscription in stateChangeHandledSubscriptions {
-                subscription.emit(stateChange)
-            }
+            stateChangeHandledSubscriptions.emit(stateChange)
         #endif
     }
 
     #if DEBUG
         private func emitTransientDisconnectTimeoutHandledEventForTimeoutWithID(_ id: UUID) {
             logger.log(message: "Emitting transient disconnect timeout handled event for \(id)", level: .debug)
-            for subscription in transientDisconnectTimeoutHandledSubscriptions {
-                subscription.emit(id)
-            }
+            transientDisconnectTimeoutHandledSubscriptions.emit(id)
         }
     #endif
 
@@ -636,15 +608,12 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
             internal var waitedOperationID: UUID
         }
 
-        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         /// Supports the ``testsOnly_subscribeToOperationWaitEvents()`` method.
-        private var operationWaitEventSubscriptions: [Subscription<OperationWaitEvent>] = []
+        private var operationWaitEventSubscriptions = SubscriptionStorage<OperationWaitEvent>()
 
         /// Returns a subscription which emits an event each time one room lifecycle operation is going to wait for another to complete.
         internal func testsOnly_subscribeToOperationWaitEvents() -> Subscription<OperationWaitEvent> {
-            let subscription = Subscription<OperationWaitEvent>(bufferingPolicy: .unbounded)
-            operationWaitEventSubscriptions.append(subscription)
-            return subscription
+            operationWaitEventSubscriptions.create(bufferingPolicy: .unbounded)
         }
     #endif
 
@@ -693,9 +662,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
 
                 #if DEBUG
                     let operationWaitEvent = OperationWaitEvent(waitingOperationID: requester.waitingOperationID, waitedOperationID: waitedOperationID)
-                    for subscription in operationWaitEventSubscriptions {
-                        subscription.emit(operationWaitEvent)
-                    }
+                    operationWaitEventSubscriptions.emit(operationWaitEvent)
                 #endif
             }
 
@@ -1265,9 +1232,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
             let subscription = onRoomStatusChange(bufferingPolicy: .unbounded)
             logger.log(message: "waitToBeAbleToPerformPresenceOperations waiting for status change", level: .debug)
             #if DEBUG
-                for subscription in statusChangeWaitEventSubscriptions {
-                    subscription.emit(.init())
-                }
+                statusChangeWaitEventSubscriptions.emit(.init())
             #endif
             let nextRoomStatusChange = await (subscription.first { _ in true })
             logger.log(message: "waitToBeAbleToPerformPresenceOperations got status change \(String(describing: nextRoomStatusChange))", level: .debug)
@@ -1293,15 +1258,12 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
             // Nothing here currently, just created this type for consistency with OperationWaitEvent
         }
 
-        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         /// Supports the ``testsOnly_subscribeToStatusChangeWaitEvents()`` method.
-        private var statusChangeWaitEventSubscriptions: [Subscription<StatusChangeWaitEvent>] = []
+        private var statusChangeWaitEventSubscriptions = SubscriptionStorage<StatusChangeWaitEvent>()
 
         /// Returns a subscription which emits an event each time ``waitToBeAbleToPerformPresenceOperations(requestedByFeature:)`` is going to wait for a room status change.
         internal func testsOnly_subscribeToStatusChangeWaitEvents() -> Subscription<StatusChangeWaitEvent> {
-            let subscription = Subscription<StatusChangeWaitEvent>(bufferingPolicy: .unbounded)
-            statusChangeWaitEventSubscriptions.append(subscription)
-            return subscription
+            statusChangeWaitEventSubscriptions.create(bufferingPolicy: .unbounded)
         }
     #endif
 }

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -137,22 +137,17 @@ internal actor DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
             internal var waitedOperationType: OperationType
         }
 
-        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
         /// Supports the ``testsOnly_subscribeToOperationWaitEvents()`` method.
-        private var operationWaitEventSubscriptions: [Subscription<OperationWaitEvent>] = []
+        private var operationWaitEventSubscriptions = SubscriptionStorage<OperationWaitEvent>()
 
         /// Returns a subscription which emits an event each time one operation is going to wait for another to complete.
         internal func testsOnly_subscribeToOperationWaitEvents() -> Subscription<OperationWaitEvent> {
-            let subscription = Subscription<OperationWaitEvent>(bufferingPolicy: .unbounded)
-            operationWaitEventSubscriptions.append(subscription)
-            return subscription
+            operationWaitEventSubscriptions.create(bufferingPolicy: .unbounded)
         }
 
         private func emitOperationWaitEvent(waitingOperationType: OperationType, waitedOperationType: OperationType) {
             let operationWaitEvent = OperationWaitEvent(waitingOperationType: waitingOperationType, waitedOperationType: waitedOperationType)
-            for subscription in operationWaitEventSubscriptions {
-                subscription.emit(operationWaitEvent)
-            }
+            operationWaitEventSubscriptions.emit(operationWaitEvent)
         }
     #endif
 

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -5,7 +5,7 @@
 // At some point we should define how this thing behaves when you iterate over it from multiple loops, or when you pass it around. I’m not yet sufficiently experienced with `AsyncSequence` to know what’s idiomatic. I tried the same thing out with `AsyncStream` (two tasks iterating over a single stream) and it appears that each element is delivered to precisely one consumer. But we can leave that for later. On a similar note consider whether it makes a difference whether this is a struct or a class.
 //
 // I wanted to implement this as a protocol (from which `MessageSubscription` would then inherit) but struggled to do so (see https://forums.swift.org/t/struggling-to-create-a-protocol-that-inherits-from-asyncsequence-with-primary-associated-type/73950 where someone suggested it’s a compiler bug), hence the struct. I was also hoping that upon switching to Swift 6 we could use AsyncSequence’s `Failure` associated type to simplify the way in which we show that the subscription is non-throwing, but it turns out this can only be done in macOS 15 etc. So I think that for now we’re stuck with things the way they are.
-public struct Subscription<Element: Sendable>: Sendable, AsyncSequence {
+public final class Subscription<Element: Sendable>: Sendable, AsyncSequence {
     private enum Mode: Sendable {
         case `default`(stream: AsyncStream<Element>, continuation: AsyncStream<Element>.Continuation)
         case mockAsyncSequence(AnyNonThrowingAsyncSequence)

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // A non-throwing `AsyncSequence` (means that we can iterate over it without a `try`).
 //
 // This should respect the `BufferingPolicy` passed to the `subscribe(bufferingPolicy:)` method.
@@ -5,7 +7,11 @@
 // At some point we should define how this thing behaves when you iterate over it from multiple loops, or when you pass it around. I’m not yet sufficiently experienced with `AsyncSequence` to know what’s idiomatic. I tried the same thing out with `AsyncStream` (two tasks iterating over a single stream) and it appears that each element is delivered to precisely one consumer. But we can leave that for later. On a similar note consider whether it makes a difference whether this is a struct or a class.
 //
 // I wanted to implement this as a protocol (from which `MessageSubscription` would then inherit) but struggled to do so (see https://forums.swift.org/t/struggling-to-create-a-protocol-that-inherits-from-asyncsequence-with-primary-associated-type/73950 where someone suggested it’s a compiler bug), hence the struct. I was also hoping that upon switching to Swift 6 we could use AsyncSequence’s `Failure` associated type to simplify the way in which we show that the subscription is non-throwing, but it turns out this can only be done in macOS 15 etc. So I think that for now we’re stuck with things the way they are.
-public final class Subscription<Element: Sendable>: Sendable, AsyncSequence {
+
+/// A non-throwing `AsyncSequence`. The Chat SDK uses this type as the return value of the methods that allow you to find out about events such as typing events, connection status changes, discontinuity events etc.
+///
+/// You should only iterate over a given `Subscription` once; the results of iterating more than once are undefined.
+public final class Subscription<Element: Sendable>: @unchecked Sendable, AsyncSequence {
     private enum Mode: Sendable {
         case `default`(stream: AsyncStream<Element>, continuation: AsyncStream<Element>.Continuation)
         case mockAsyncSequence(AnyNonThrowingAsyncSequence)
@@ -45,6 +51,9 @@ public final class Subscription<Element: Sendable>: Sendable, AsyncSequence {
         }
     }
 
+    // Access must be synchronised using ``lock``.
+    private var terminationHandlers: [@Sendable () -> Void] = []
+    private let lock = NSLock()
     private let mode: Mode
 
     internal init(bufferingPolicy: BufferingPolicy) {
@@ -71,13 +80,24 @@ public final class Subscription<Element: Sendable>: Sendable, AsyncSequence {
         }
     }
 
-    // TODO: https://github.com/ably-labs/ably-chat-swift/issues/36 Revisit how we want to unsubscribe to fulfil CHA-M4b & CHA-ER4b. I think exposing this publicly for all Subscription types is suitable.
-    public func unsubscribe() {
+    internal func addTerminationHandler(_ terminationHandler: @escaping (@Sendable () -> Void)) {
+        var terminationHandlers: [@Sendable () -> Void]
+        lock.lock()
+        terminationHandlers = self.terminationHandlers
+        terminationHandlers.append(terminationHandler)
+        self.terminationHandlers = terminationHandlers
+        lock.unlock()
+
         switch mode {
         case let .default(_, continuation):
-            continuation.finish()
+            let constantTerminationHandlers = terminationHandlers
+            continuation.onTermination = { _ in
+                for terminationHandler in constantTerminationHandlers {
+                    terminationHandler()
+                }
+            }
         case .mockAsyncSequence:
-            fatalError("`finish` cannot be called on a Subscription that was created using init(mockAsyncSequence:)")
+            fatalError("`addTerminationHandler(_:)` cannot be called on a Subscription that was created using init(mockAsyncSequence:)")
         }
     }
 

--- a/Sources/AblyChat/SubscriptionStorage.swift
+++ b/Sources/AblyChat/SubscriptionStorage.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Maintains a list of `Subscription` objects, from which it removes a subscription once the subscription is no longer in use.
+///
+/// Offers the ability to create a new subscription (using ``create(bufferingPolicy:)``) or to emit a value on all subscriptions (using ``emit(_:)``).
+internal class SubscriptionStorage<Element: Sendable>: @unchecked Sendable {
+    // A note about the use of `@unchecked Sendable` here: This is a type that updates its own state in response to external events (i.e. subscription termination), and I wasn’t sure how to perform this mutation in the context of some external actor that owns the mutable state held in this type. So instead I made this class own its mutable state and take responsibility for its synchronisation, and I decided to do perform this synchronisation manually instead of introducing _another_ layer of actors for something that really doesn’t seem like it should be an actor; it’s just meant to be a utility type. But we can revisit this decision.
+
+    // We hold a weak reference to the subscriptions that we create, so that the subscriptions’ termination handlers get called when the user releases their final reference to the subscription.
+    private struct WeaklyHeldSubscription {
+        internal weak var subscription: Subscription<Element>?
+    }
+
+    /// Access must be synchronised via ``lock``.
+    private var subscriptions: [UUID: WeaklyHeldSubscription] = [:]
+    private let lock = NSLock()
+
+    /// Creates a subscription and adds it to the list managed by this `SubscriptionStorage` instance.
+    ///
+    /// The `SubscriptionStorage` instance will remove this subscription from its list once the subscription “terminates” (meaning that there are no longer any references to it, or the task in which it was being iterated was cancelled).
+    internal func create(bufferingPolicy: BufferingPolicy) -> Subscription<Element> {
+        let subscription = Subscription<Element>(bufferingPolicy: bufferingPolicy)
+        let id = UUID()
+
+        lock.lock()
+        subscriptions[id] = .init(subscription: subscription)
+        lock.unlock()
+
+        subscription.addTerminationHandler { [weak self] in
+            self?.subscriptionDidTerminate(id: id)
+        }
+
+        return subscription
+    }
+
+    #if DEBUG
+        internal var testsOnly_subscriptionCount: Int {
+            let count: Int
+            lock.lock()
+            count = subscriptions.count
+            lock.unlock()
+            return count
+        }
+    #endif
+
+    private func subscriptionDidTerminate(id: UUID) {
+        lock.lock()
+        subscriptions.removeValue(forKey: id)
+        lock.unlock()
+    }
+
+    /// Emits an element on all of the subscriptions in the reciever’s managed list.
+    internal func emit(_ element: Element) {
+        lock.lock()
+        for subscription in subscriptions.values {
+            subscription.subscription?.emit(element)
+        }
+        lock.unlock()
+    }
+}

--- a/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
@@ -3,8 +3,7 @@ import Ably
 
 final actor MockFeatureChannel: FeatureChannel {
     let channel: RealtimeChannelProtocol
-    // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
-    private var discontinuitySubscriptions: [Subscription<DiscontinuityEvent>] = []
+    private var discontinuitySubscriptions = SubscriptionStorage<DiscontinuityEvent>()
     private let resultOfWaitToBeAbleToPerformPresenceOperations: Result<Void, ARTErrorInfo>?
 
     init(
@@ -16,15 +15,11 @@ final actor MockFeatureChannel: FeatureChannel {
     }
 
     func onDiscontinuity(bufferingPolicy: BufferingPolicy) async -> Subscription<DiscontinuityEvent> {
-        let subscription = Subscription<DiscontinuityEvent>(bufferingPolicy: bufferingPolicy)
-        discontinuitySubscriptions.append(subscription)
-        return subscription
+        discontinuitySubscriptions.create(bufferingPolicy: bufferingPolicy)
     }
 
     func emitDiscontinuity(_ discontinuity: DiscontinuityEvent) {
-        for subscription in discontinuitySubscriptions {
-            subscription.emit(discontinuity)
-        }
+        discontinuitySubscriptions.emit(discontinuity)
     }
 
     func waitToBeAbleToPerformPresenceOperations(requestedByFeature _: RoomFeature) async throws(ARTErrorInfo) {

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -163,7 +163,7 @@ final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
     }
 
     func unsubscribe(_: ARTEventListener?) {
-        fatalError("Not implemented")
+        // no-op; revisit if we need to test something that depends on this method actually stopping `subscribe` from emitting more events
     }
 
     func unsubscribe(_: String, listener _: ARTEventListener?) {
@@ -199,7 +199,7 @@ final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
     }
 
     func off(_: ARTEventListener) {
-        fatalError("Not implemented")
+        // no-op; revisit if we need to test something that depends on this method actually stopping `on` from emitting more events
     }
 
     func off() {

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleContributorChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleContributorChannel.swift
@@ -8,8 +8,7 @@ final actor MockRoomLifecycleContributorChannel: RoomLifecycleContributorChannel
 
     var state: ARTRealtimeChannelState
     var errorReason: ARTErrorInfo?
-    // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
-    private var subscriptions: [Subscription<ARTChannelStateChange>] = []
+    private var subscriptions = SubscriptionStorage<ARTChannelStateChange>()
 
     private(set) var attachCallCount = 0
     private(set) var detachCallCount = 0
@@ -108,8 +107,7 @@ final actor MockRoomLifecycleContributorChannel: RoomLifecycleContributorChannel
     }
 
     func subscribeToState() -> Subscription<ARTChannelStateChange> {
-        let subscription = Subscription<ARTChannelStateChange>(bufferingPolicy: .unbounded)
-        subscriptions.append(subscription)
+        let subscription = subscriptions.create(bufferingPolicy: .unbounded)
 
         switch subscribeToStateBehavior {
         case .justAddSubscription:
@@ -122,8 +120,6 @@ final actor MockRoomLifecycleContributorChannel: RoomLifecycleContributorChannel
     }
 
     func emitStateChange(_ stateChange: ARTChannelStateChange) {
-        for subscription in subscriptions {
-            subscription.emit(stateChange)
-        }
+        subscriptions.emit(stateChange)
     }
 }

--- a/Tests/AblyChatTests/SubscriptionStorageTests.swift
+++ b/Tests/AblyChatTests/SubscriptionStorageTests.swift
@@ -1,0 +1,40 @@
+@testable import AblyChat
+import Testing
+
+struct SubscriptionStorageTests {
+    @Test
+    func emit() async throws {
+        let storage = SubscriptionStorage<String>()
+        let subscriptions = (0 ..< 10).map { _ in storage.create(bufferingPolicy: .unbounded) }
+        storage.emit("hello")
+
+        var emittedElements: [String] = []
+        for subscription in subscriptions {
+            try emittedElements.append(#require(await subscription.first { _ in true }))
+        }
+
+        #expect(emittedElements == Array(repeating: "hello", count: 10))
+    }
+
+    @Test
+    func removesSubscriptionOnTermination() async throws {
+        let storage = SubscriptionStorage<String>()
+        let subscriptionTerminatedSignal = AsyncStream<Void>.makeStream()
+
+        ({
+            let subscription = storage.create(bufferingPolicy: .unbounded)
+            subscription.addTerminationHandler {
+                subscriptionTerminatedSignal.continuation.yield()
+            }
+
+            withExtendedLifetime(subscription) {
+                #expect(storage.testsOnly_subscriptionCount == 1)
+            }
+
+            // Now there are no more references to `subscription`.
+        })()
+
+        await subscriptionTerminatedSignal.stream.first { _ in true }
+        #expect(storage.testsOnly_subscriptionCount == 0)
+    }
+}


### PR DESCRIPTION
Hook in to `AsyncStream`’s termination notification mechanism, so that when the user discards a subscription or cancels the task in which they’re iterating over a subscription, we:

- remove this subscription from our internal data structures
- remove any corresponding ably-cocoa listeners that drive this
  subscription

I’m sure that there will turn out to be a bunch of wrong stuff that I’ve done here, due to my still-shaky knowledge of concurrency stuff and `AsyncSequence` best practices, but it’s a start.

(I still need to update the documentation in https://github.com/ably/docs/ to reflect the removal of `unsubscribe`.)

Resolves #36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Based on the comprehensive summary, here are the updated release notes:

- **New Features**
	- Enhanced subscription management with improved resource cleanup and termination handling.
	- Introduced `SubscriptionStorage` for more efficient subscription tracking.
	- Added termination handlers for subscriptions to manage lifecycle events.

- **Improvements**
	- Refactored subscription mechanisms across multiple components.
	- Improved thread-safety for subscription management.
	- Updated documentation for subscription and event handling.

- **Technical Changes**
	- Transitioned from struct to class for certain subscription types.
	- Implemented more robust async sequence handling.
	- Added new methods for managing subscription lifecycles.

- **Testing**
	- Added comprehensive test suite for new subscription management features.
	- Introduced tests for termination and resource cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->