### PR TITLE
[ECO-5018] Use wrapper SDK proxy to track Chat SDK usage

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "77e4b2b661f9de38584f7d61ba62b95f5fe6ef751d01e208399bed3950246e2b",
+  "originHash" : "1642b4839120f35594f234f50e4692c898bd27f9ab378d75c8b8cc23e3955b51",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "35805d0e96a1df5b4dc0f6d82afe22ab753c15bd",
-        "version" : "1.2.37"
+        "revision" : "11f67876d3f2070ac976f639c4cc959d2995e1ca",
+        "version" : "1.2.38"
       }
     },
     {

--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -16,7 +16,7 @@ private enum Environment: Equatable {
         switch self {
         case .mock:
             return MockChatClient(
-                realtime: MockRealtime.create(),
+                realtime: MockRealtime(),
                 clientOptions: ClientOptions()
             )
         case let .live(key: key, clientId: clientId):

--- a/Example/AblyChatExample/Mocks/MockRealtime.swift
+++ b/Example/AblyChatExample/Mocks/MockRealtime.swift
@@ -344,21 +344,6 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, Sendable {
         }
     }
 
-    required init(options _: ARTClientOptions) {}
-
-    required init(key _: String) {}
-
-    required init(token _: String) {}
-
-    /**
-     Creates an instance of MockRealtime.
-
-     This exists to give a convenient way to create an instance, because `init` is marked as unavailable in `ARTRealtimeProtocol`.
-     */
-    static func create() -> MockRealtime {
-        MockRealtime(key: "")
-    }
-
     func time(_: @escaping ARTDateTimeCallback) {
         fatalError("Not implemented")
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "8c7acde3826a921568cc75459ff2052ebec85d53398758c637099c1128f45e32",
+  "originHash" : "37fce824816ce268471c881861e4f5083c97a5b677b2060fdad5e31fab9cd658",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "35805d0e96a1df5b4dc0f6d82afe22ab753c15bd",
-        "version" : "1.2.37"
+        "revision" : "11f67876d3f2070ac976f639c4cc959d2995e1ca",
+        "version" : "1.2.38"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.37"
+            from: "1.2.38"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
@@ -1,10 +1,14 @@
 import Ably
 
-extension ARTRealtime: RealtimeClientProtocol {}
+extension ARTRealtime: SuppliedRealtimeClientProtocol {}
+
+extension ARTWrapperSDKProxyRealtime: RealtimeClientProtocol {}
 
 extension ARTRealtimeChannels: RealtimeChannelsProtocol {}
+extension ARTWrapperSDKProxyRealtimeChannels: RealtimeChannelsProtocol {}
 
 extension ARTRealtimeChannel: RealtimeChannelProtocol {}
+extension ARTWrapperSDKProxyRealtimeChannel: RealtimeChannelProtocol {}
 
 extension ARTRealtimePresence: RealtimePresenceProtocol {}
 

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -44,7 +44,7 @@ public typealias RealtimeClient = any RealtimeClientProtocol
  * This is the core client for Ably chat. It provides access to chat rooms.
  */
 public actor DefaultChatClient: ChatClient {
-    public let realtime: RealtimeClient
+    public nonisolated let realtime: RealtimeClient
     public nonisolated let clientOptions: ClientOptions
     public nonisolated let rooms: Rooms
     private let logger: InternalLogger

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -60,9 +60,12 @@ public actor DefaultChatClient: ChatClient {
      *   - realtime: The Ably Realtime client.
      *   - clientOptions: The client options.
      */
-    public init(realtime: RealtimeClient, clientOptions: ClientOptions?) {
-        self.realtime = realtime
+    public init(realtime suppliedRealtime: any SuppliedRealtimeClientProtocol, clientOptions: ClientOptions?) {
+        self.realtime = suppliedRealtime
         self.clientOptions = clientOptions ?? .init()
+
+        let realtime = suppliedRealtime.createWrapperSDKProxy(with: .init(agents: agents))
+
         logger = DefaultInternalLogger(logHandler: self.clientOptions.logHandler, logLevel: self.clientOptions.logLevel)
         let roomFactory = DefaultRoomFactory()
         rooms = DefaultRooms(realtime: realtime, clientOptions: self.clientOptions, logger: logger, roomFactory: roomFactory)

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -3,6 +3,13 @@ import Ably
 /// Expresses the requirements of the Ably realtime client that is supplied to the Chat SDK.
 ///
 /// The `ARTRealtime` class from the ably-cocoa SDK implements this protocol.
+public protocol SuppliedRealtimeClientProtocol: Sendable, RealtimeClientProtocol {
+    associatedtype ProxyClient: RealtimeClientProtocol
+
+    func createWrapperSDKProxy(with options: ARTWrapperSDKProxyOptions) -> ProxyClient
+}
+
+/// Expresses the requirements of the object returned by ``SuppliedRealtimeClientProtocol/createWrapperSDKProxy(with:)``.
 public protocol RealtimeClientProtocol: ARTRealtimeInstanceMethodsProtocol, Sendable {
     associatedtype Channels: RealtimeChannelsProtocol
     associatedtype Connection: ConnectionProtocol
@@ -55,16 +62,9 @@ internal struct RealtimeChannelOptions {
 }
 
 internal extension RealtimeClientProtocol {
-    // Function to get the channel with merged options
+    // Function to get the channel with Chat's default options
     func getChannel(_ name: String, opts: RealtimeChannelOptions? = nil) -> any RealtimeChannelProtocol {
         var resolvedOptions = opts ?? .init()
-
-        // Add in the default params
-        resolvedOptions.params = (resolvedOptions.params ?? [:]).merging(
-            defaultChannelParams
-        ) { _, new
-            in new
-        }
 
         // CHA-GP2a
         resolvedOptions.attachOnSubscribe = false

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -3,7 +3,7 @@ import Ably
 /// Expresses the requirements of the Ably realtime client that is supplied to the Chat SDK.
 ///
 /// The `ARTRealtime` class from the ably-cocoa SDK implements this protocol.
-public protocol RealtimeClientProtocol: ARTRealtimeProtocol, Sendable {
+public protocol RealtimeClientProtocol: ARTRealtimeInstanceMethodsProtocol, Sendable {
     associatedtype Channels: RealtimeChannelsProtocol
     associatedtype Connection: ConnectionProtocol
 

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -38,37 +38,19 @@ public protocol RealtimePresenceProtocol: ARTRealtimePresenceProtocol, Sendable 
 /// Expresses the requirements of the object returned by ``RealtimeClientProtocol/connection``.
 public protocol ConnectionProtocol: ARTConnectionProtocol, Sendable {}
 
-/// Like (a subset of) `ARTRealtimeChannelOptions` but with value semantics. (It’s unfortunate that `ARTRealtimeChannelOptions` doesn’t have a `-copy` method.)
-internal struct RealtimeChannelOptions {
-    internal var modes: ARTChannelMode
-    internal var params: [String: String]?
-    internal var attachOnSubscribe: Bool
-
-    internal init() {
-        // Get our default values from ably-cocoa
-        let artRealtimeChannelOptions = ARTRealtimeChannelOptions()
-        modes = artRealtimeChannelOptions.modes
-        params = artRealtimeChannelOptions.params
-        attachOnSubscribe = artRealtimeChannelOptions.attachOnSubscribe
-    }
-
-    internal var toARTRealtimeChannelOptions: ARTRealtimeChannelOptions {
-        let result = ARTRealtimeChannelOptions()
-        result.modes = modes
-        result.params = params
-        result.attachOnSubscribe = attachOnSubscribe
-        return result
-    }
-}
-
 internal extension RealtimeClientProtocol {
     // Function to get the channel with Chat's default options
-    func getChannel(_ name: String, opts: RealtimeChannelOptions? = nil) -> any RealtimeChannelProtocol {
-        var resolvedOptions = opts ?? .init()
+    func getChannel(_ name: String, opts: ARTRealtimeChannelOptions? = nil) -> any RealtimeChannelProtocol {
+        let resolvedOptions: ARTRealtimeChannelOptions = if let opts {
+            // swiftlint:disable:next force_cast
+            opts.copy() as! ARTRealtimeChannelOptions
+        } else {
+            .init()
+        }
 
         // CHA-GP2a
         resolvedOptions.attachOnSubscribe = false
 
-        return channels.get(name, options: resolvedOptions.toARTRealtimeChannelOptions)
+        return channels.get(name, options: resolvedOptions)
     }
 }

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -315,7 +315,7 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
         let featuresGroupedByChannelName = Dictionary(grouping: featuresWithOptions) { $0.toRoomFeature.channelNameForRoomID(roomID) }
 
         let unorderedResult = featuresGroupedByChannelName.map { channelName, features in
-            var channelOptions = RealtimeChannelOptions()
+            let channelOptions = ARTRealtimeChannelOptions()
 
             // channel setup for presence and occupancy
             for feature in features {

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -6,6 +6,4 @@ import Ably
 // Version information
 internal let version = "0.1.2"
 
-internal let channelOptionsAgentString = "chat-swift/\(version)"
-
-internal let defaultChannelParams = ["agent": channelOptionsAgentString]
+internal let agents = ["chat-swift": version]

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -8,7 +8,7 @@ struct ChatAPITests {
     @Test
     func sendMessage_whenSendMessageReturnsNoItems_throwsNoItemInResponse() async {
         // Given
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (MockHTTPPaginatedResponse.successSendMessageWithNoItems, nil)
         }
         let chatAPI = ChatAPI(realtime: realtime)
@@ -29,7 +29,7 @@ struct ChatAPITests {
     @Test
     func sendMessage_returnsMessage() async throws {
         // Given
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (MockHTTPPaginatedResponse.successSendMessage, nil)
         }
         let chatAPI = ChatAPI(realtime: realtime)
@@ -55,7 +55,7 @@ struct ChatAPITests {
     @Test
     func sendMessage_includesHeadersInBody() async throws {
         // Given
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (MockHTTPPaginatedResponse.successSendMessage, nil)
         }
         let chatAPI = ChatAPI(realtime: realtime)
@@ -78,7 +78,7 @@ struct ChatAPITests {
     @Test
     func sendMessage_includesMetadataInBody() async throws {
         // Given
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (MockHTTPPaginatedResponse.successSendMessage, nil)
         }
         let chatAPI = ChatAPI(realtime: realtime)
@@ -105,7 +105,7 @@ struct ChatAPITests {
     func getMessages_whenGetMessagesReturnsNoItems_returnsEmptyPaginatedResult() async {
         // Given
         let paginatedResponse = MockHTTPPaginatedResponse.successGetMessagesWithNoItems
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (paginatedResponse, nil)
         }
         let chatAPI = ChatAPI(realtime: realtime)
@@ -127,7 +127,7 @@ struct ChatAPITests {
     func getMessages_whenGetMessagesReturnsItems_returnsItemsInPaginatedResult() async {
         // Given
         let paginatedResponse = MockHTTPPaginatedResponse.successGetMessagesWithItems
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (paginatedResponse, nil)
         }
         let chatAPI = ChatAPI(realtime: realtime)
@@ -171,7 +171,7 @@ struct ChatAPITests {
         // Given
         let paginatedResponse = MockHTTPPaginatedResponse.successGetMessagesWithNoItems
         let artError = ARTErrorInfo.create(withCode: 50000, message: "Internal server error")
-        let realtime = MockRealtime.create {
+        let realtime = MockRealtime {
             (paginatedResponse, artError)
         }
         let chatAPI = ChatAPI(realtime: realtime)

--- a/Tests/AblyChatTests/DefaultChatClientTests.swift
+++ b/Tests/AblyChatTests/DefaultChatClientTests.swift
@@ -5,7 +5,10 @@ struct DefaultChatClientTests {
     @Test
     func init_withoutClientOptions() {
         // Given: An instance of DefaultChatClient is created with nil clientOptions
-        let client = DefaultChatClient(realtime: MockRealtime(), clientOptions: nil)
+        let client = DefaultChatClient(
+            realtime: MockRealtime(createWrapperSDKProxyReturnValue: .init()),
+            clientOptions: nil
+        )
 
         // Then: It uses the default client options
         let defaultOptions = ClientOptions()
@@ -13,17 +16,38 @@ struct DefaultChatClientTests {
     }
 
     @Test
-    func rooms() throws {
+    func test_realtime() {
         // Given: An instance of DefaultChatClient
-        let realtime = MockRealtime()
+        let realtime = MockRealtime(createWrapperSDKProxyReturnValue: .init())
         let options = ClientOptions()
         let client = DefaultChatClient(realtime: realtime, clientOptions: options)
 
-        // Then: Its `rooms` property returns an instance of DefaultRooms with the same realtime client and client options
+        // Then: Its `realtime` property returns the client that was passed to the initializer (i.e. as opposed to the proxy client created by `createWrapperSDKProxy(with:)`
+        #expect(client.realtime === realtime)
+    }
+
+    @Test
+    func createsWrapperSDKProxyRealtimeClientWithAgents() throws {
+        let realtime = MockRealtime(createWrapperSDKProxyReturnValue: .init())
+        let options = ClientOptions()
+        _ = DefaultChatClient(realtime: realtime, clientOptions: options)
+
+        #expect(realtime.createWrapperSDKProxyOptionsArgument?.agents == ["chat-swift": AblyChat.version])
+    }
+
+    @Test
+    func rooms() throws {
+        // Given: An instance of DefaultChatClient
+        let proxyClient = MockRealtime()
+        let realtime = MockRealtime(createWrapperSDKProxyReturnValue: proxyClient)
+        let options = ClientOptions()
+        let client = DefaultChatClient(realtime: realtime, clientOptions: options)
+
+        // Then: Its `rooms` property returns an instance of DefaultRooms with the wrapper SDK proxy realtime client and same client options
         let rooms = client.rooms
 
         let defaultRooms = try #require(rooms as? DefaultRooms<DefaultRoomFactory>)
-        #expect(defaultRooms.testsOnly_realtime === realtime)
+        #expect(defaultRooms.testsOnly_realtime === proxyClient)
         #expect(defaultRooms.clientOptions.isEqualForTestPurposes(options))
     }
 }

--- a/Tests/AblyChatTests/DefaultChatClientTests.swift
+++ b/Tests/AblyChatTests/DefaultChatClientTests.swift
@@ -5,7 +5,7 @@ struct DefaultChatClientTests {
     @Test
     func init_withoutClientOptions() {
         // Given: An instance of DefaultChatClient is created with nil clientOptions
-        let client = DefaultChatClient(realtime: MockRealtime.create(), clientOptions: nil)
+        let client = DefaultChatClient(realtime: MockRealtime(), clientOptions: nil)
 
         // Then: It uses the default client options
         let defaultOptions = ClientOptions()
@@ -15,7 +15,7 @@ struct DefaultChatClientTests {
     @Test
     func rooms() throws {
         // Given: An instance of DefaultChatClient
-        let realtime = MockRealtime.create()
+        let realtime = MockRealtime()
         let options = ClientOptions()
         let client = DefaultChatClient(realtime: realtime, clientOptions: options)
 

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -8,7 +8,7 @@ struct DefaultMessagesTests {
         // roomId and clientId values are arbitrary
 
         // Given
-        let realtime = MockRealtime.create()
+        let realtime = MockRealtime()
         let chatAPI = ChatAPI(realtime: realtime)
         let channel = MockRealtimeChannel()
         let featureChannel = MockFeatureChannel(channel: channel)
@@ -26,7 +26,7 @@ struct DefaultMessagesTests {
         // Message response of succcess with no items, and roomId are arbitrary
 
         // Given
-        let realtime = MockRealtime.create { (MockHTTPPaginatedResponse.successGetMessagesWithNoItems, nil) }
+        let realtime = MockRealtime { (MockHTTPPaginatedResponse.successGetMessagesWithNoItems, nil) }
         let chatAPI = ChatAPI(realtime: realtime)
         let channel = MockRealtimeChannel()
         let featureChannel = MockFeatureChannel(channel: channel)
@@ -46,7 +46,7 @@ struct DefaultMessagesTests {
         // all setup values here are arbitrary
 
         // Given
-        let realtime = MockRealtime.create { (MockHTTPPaginatedResponse.successGetMessagesWithNoItems, nil) }
+        let realtime = MockRealtime { (MockHTTPPaginatedResponse.successGetMessagesWithNoItems, nil) }
         let chatAPI = ChatAPI(realtime: realtime)
         let channel = MockRealtimeChannel(
             properties: .init(
@@ -72,7 +72,7 @@ struct DefaultMessagesTests {
     @Test
     func subscribe_extractsHeadersFromChannelMessage() async throws {
         // Given
-        let realtime = MockRealtime.create()
+        let realtime = MockRealtime()
         let chatAPI = ChatAPI(realtime: realtime)
 
         let channel = MockRealtimeChannel(
@@ -106,7 +106,7 @@ struct DefaultMessagesTests {
     @Test
     func subscribe_extractsMetadataFromChannelMessage() async throws {
         // Given
-        let realtime = MockRealtime.create()
+        let realtime = MockRealtime()
         let chatAPI = ChatAPI(realtime: realtime)
 
         let channel = MockRealtimeChannel(
@@ -140,7 +140,7 @@ struct DefaultMessagesTests {
     @Test
     func onDiscontinuity() async throws {
         // Given: A DefaultMessages instance
-        let realtime = MockRealtime.create()
+        let realtime = MockRealtime()
         let chatAPI = ChatAPI(realtime: realtime)
         let channel = MockRealtimeChannel()
         let featureChannel = MockFeatureChannel(channel: channel)

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -13,7 +13,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
         _ = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .init(), logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
 
         // Then: When it fetches a channel, it does so with the `attachOnSubscribe` channel option set to false
@@ -30,7 +30,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
         let roomOptions = RoomOptions(presence: PresenceOptions(), occupancy: OccupancyOptions())
         _ = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
 
@@ -54,7 +54,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
         let room = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .init(), logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
 
         // Then
@@ -73,7 +73,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$reactions"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
         let roomOptions = RoomOptions(
             presence: .init(),
             // Note that typing indicators are not enabled, to give us the aforementioned strict subset of features
@@ -111,7 +111,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
         let lifecycleManagerFactory = MockRoomLifecycleManagerFactory()
         _ = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .allFeaturesEnabled, logger: TestLogger(), lifecycleManagerFactory: lifecycleManagerFactory)
 
@@ -152,7 +152,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: name)
         }
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
         let room = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
 
         // When: We call the room’s getter for that feature
@@ -185,7 +185,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
 
         let lifecycleManager = MockRoomLifecycleManager(attachResult: managerAttachResult)
         let lifecycleManagerFactory = MockRoomLifecycleManagerFactory(manager: lifecycleManager)
@@ -221,7 +221,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
 
         let lifecycleManager = MockRoomLifecycleManager(detachResult: managerDetachResult)
         let lifecycleManagerFactory = MockRoomLifecycleManagerFactory(manager: lifecycleManager)
@@ -253,7 +253,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
 
         let lifecycleManager = MockRoomLifecycleManager()
         let lifecycleManagerFactory = MockRoomLifecycleManagerFactory(manager: lifecycleManager)
@@ -279,7 +279,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
 
         let lifecycleManagerRoomStatus = RoomStatus.attached // arbitrary
 
@@ -299,7 +299,7 @@ struct DefaultRoomTests {
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
         ]
         let channels = MockChannels(channels: channelsList)
-        let realtime = MockRealtime.create(channels: channels)
+        let realtime = MockRealtime(channels: channels)
 
         let lifecycleManager = MockRoomLifecycleManager()
         let lifecycleManagerFactory = MockRoomLifecycleManagerFactory(manager: lifecycleManager)

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -36,7 +36,7 @@ struct DefaultRoomsTests {
     @Test
     func get_returnsRoomWithGivenIDAndOptions() async throws {
         // Given: an instance of DefaultRooms
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let options = RoomOptions()
@@ -64,7 +64,7 @@ struct DefaultRoomsTests {
     @Test
     func get_whenRoomExistsInRoomMap_returnsExistingRoomWithGivenID() async throws {
         // Given: an instance of DefaultRooms, which has, per CHA-RC1f3, a room in the room map with a given ID
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let options = RoomOptions()
@@ -87,7 +87,7 @@ struct DefaultRoomsTests {
     @Test
     func get_whenFutureExistsInRoomMap_returnsExistingRoomWithGivenID() async throws {
         // Given: an instance of DefaultRooms, for which, per CHA-RC1f4, a previous call to get(roomID:options:) with a given ID is waiting for a CHA-RC1g release operation to complete
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let options = RoomOptions()
@@ -131,7 +131,7 @@ struct DefaultRoomsTests {
     @Test
     func get_whenRoomExistsInRoomMap_throwsErrorWhenOptionsDoNotMatch() async throws {
         // Given: an instance of DefaultRooms, which has, per CHA-RC1f3, a room in the room map with a given ID and options
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let options = RoomOptions()
@@ -157,7 +157,7 @@ struct DefaultRoomsTests {
     @Test
     func get_whenFutureExistsInRoomMap_throwsErrorWhenOptionsDoNotMatch() async throws {
         // Given: an instance of DefaultRooms, for which, per CHA-RC1f4, a previous call to get(roomID:options:) with a given ID and options is waiting for a CHA-RC1g release operation to complete
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let options = RoomOptions()
@@ -200,7 +200,7 @@ struct DefaultRoomsTests {
     @Test
     func get_whenReleaseInProgress() async throws {
         // Given: an instance of DefaultRooms, for which a CHA-RC1g release operation is in progrss
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
 
@@ -242,7 +242,7 @@ struct DefaultRoomsTests {
     @Test
     func release_withNoRoomMapEntry_andNoReleaseInProgress() async throws {
         // Given: An instance of DefaultRooms, with neither a room map entry nor a release operation in progress for a given room ID
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let roomFactory = MockRoomFactory()
@@ -258,7 +258,7 @@ struct DefaultRoomsTests {
     @Test
     func release_withNoRoomMapEntry_andReleaseInProgress() async throws {
         // Given: an instance of DefaultRooms, for which a release operation is in progress
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
 
@@ -298,7 +298,7 @@ struct DefaultRoomsTests {
     @Test
     func release_withReleaseInProgress_failsPendingGetOperations() async throws {
         // Given: an instance of DefaultRooms, for which there is a release operation already in progress, and a CHA-RC1f4 future in the room map awaiting the completion of this release operation
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
 
@@ -352,7 +352,7 @@ struct DefaultRoomsTests {
     @Test
     func release() async throws {
         // Given: an instance of DefaultRooms, which has a room map entry for a given room ID and has no release operation in progress for that room ID
-        let realtime = MockRealtime.create(channels: .init(channels: [
+        let realtime = MockRealtime(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
         let options = RoomOptions()

--- a/Tests/AblyChatTests/Mocks/MockRealtime.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtime.swift
@@ -30,37 +30,6 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, @unchecked Sendable 
         self.connection = connection
     }
 
-    required init(options _: ARTClientOptions) {
-        channels = .init(channels: [])
-        connection = .init()
-        paginatedCallback = nil
-    }
-
-    required init(key _: String) {
-        channels = .init(channels: [])
-        connection = .init()
-        paginatedCallback = nil
-    }
-
-    required init(token _: String) {
-        channels = .init(channels: [])
-        connection = .init()
-        paginatedCallback = nil
-    }
-
-    /**
-     Creates an instance of MockRealtime.
-
-     This exists to give a convenient way to create an instance, because `init` is marked as unavailable in `ARTRealtimeProtocol`.
-     */
-    static func create(
-        channels: MockChannels = MockChannels(channels: []),
-        connection: MockConnection = MockConnection(),
-        paginatedCallback: (@Sendable () -> (ARTHTTPPaginatedResponse?, ARTErrorInfo?))? = nil
-    ) -> MockRealtime {
-        MockRealtime(channels: channels, connection: connection, paginatedCallback: paginatedCallback)
-    }
-
     func time(_: @escaping ARTDateTimeCallback) {
         fatalError("Not implemented")
     }


### PR DESCRIPTION
This demonstrates the use of the new `-[ARTRealtime createWrapperSDKProxyWithOptions:]` method introduced in https://github.com/ably/ably-cocoa/pull/2014, which implements [ADR-117: Tracking wrapper SDK usage, continued](https://ably.atlassian.net/wiki/spaces/ENG/pages/3413016589/ADR-117+Tracking+wrapper+SDK+usage+continued), allowing us to track usage of the Chat SDK.

Once I've written a specification for the API introduced in ably-cocoa, I will also add something to the chat spec to describe the behaviour implemented in the current PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Revised dependency references for enhanced stability and consistent package management.

- **Refactor**
  - Streamlined client initialization and protocol implementations to ensure a smoother configuration flow.
  - Optimized versioning and agent information handling for improved performance.

- **Tests**
  - Updated testing approaches to match new instantiation patterns, reinforcing reliability while maintaining current functionality.
  - Added new test cases for `DefaultChatClient` to ensure correct instance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->