### PR TITLE
Bump ably-cocoa to 1.2.39

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1642b4839120f35594f234f50e4692c898bd27f9ab378d75c8b8cc23e3955b51",
+  "originHash" : "ae94e678de73d162a8e71bc1ead0d2214bbaa8f4b538125924f637df3d9c00a2",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "11f67876d3f2070ac976f639c4cc959d2995e1ca",
-        "version" : "1.2.38"
+        "revision" : "6239f6d5caacbff91e28e9a5c56f8a0f3cc1b662",
+        "version" : "1.2.39"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "37fce824816ce268471c881861e4f5083c97a5b677b2060fdad5e31fab9cd658",
+  "originHash" : "2e855624caf2790f0086192383ad61e930282bbc7a5da8b08c8dc8e1e986b194",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "11f67876d3f2070ac976f639c4cc959d2995e1ca",
-        "version" : "1.2.38"
+        "revision" : "6239f6d5caacbff91e28e9a5c56f8a0f3cc1b662",
+        "version" : "1.2.39"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.38"
+            from: "1.2.39"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
@@ -11,5 +11,6 @@ extension ARTRealtimeChannel: RealtimeChannelProtocol {}
 extension ARTWrapperSDKProxyRealtimeChannel: RealtimeChannelProtocol {}
 
 extension ARTRealtimePresence: RealtimePresenceProtocol {}
+extension ARTWrapperSDKProxyRealtimePresence: RealtimePresenceProtocol {}
 
 extension ARTConnection: ConnectionProtocol {}


### PR DESCRIPTION
We should merge this before doing our next Chat release, because Chat-`main` is not compatible with 1.2.39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced real-time presence functionality within chat, offering improved interactivity.
- **Chores**
  - Upgraded messaging dependencies to a new version to bolster stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->