### PR TITLE
docs: update README version shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p style="text-align: left">
     <img src="https://badgen.net/github/license/3scale/saas-operator" alt="License" />
-    <img src="https://img.shields.io/badge/version-0.1.0--SNAPSHOT-2ea44f" alt="version: 0.1.0-SNAPSHOT" />
+    <img alt="GitHub Release" src="https://img.shields.io/github/v/release/ably/ably-chat-swift">
 </p>
 
 Ably Chat is a set of purpose-built APIs for a host of chat features enabling you to create 1:1, 1:Many, Many:1 and Many:Many chat rooms for


### PR DESCRIPTION
The version shield still points at an old version and requires manual updating. This change replaces it with a self-updating badge that points to the GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the version badge in the SDK's documentation to display the GitHub release version.
  - Enhanced clarity of the version information presented to users without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->