### PR TITLE
[ECO-5157] [ECO-5158] Edits and Deletes

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "ae94e678de73d162a8e71bc1ead0d2214bbaa8f4b538125924f637df3d9c00a2",
+  "originHash" : "a7fd516b21dd11d1575c27de0a0a5aea3b0f6aba5c90e1cfd50d8ec79450f8dd",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "6239f6d5caacbff91e28e9a5c56f8a0f3cc1b662",
-        "version" : "1.2.39"
+        "revision" : "c5347707e4f9fb907df0e5c334de445899a79783",
+        "version" : "1.2.40"
       }
     },
     {

--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -18,7 +18,10 @@ final class MockMessagesPaginatedResult: PaginatedResult {
                 text: MockStrings.randomPhrase(),
                 createdAt: Date(),
                 metadata: [:],
-                headers: [:]
+                headers: [:],
+                version: "",
+                timestamp: Date(),
+                operation: nil
             )
         }
     }

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -15,7 +15,7 @@ actor MockChatClient: ChatClient {
     }
 
     nonisolated var clientID: String {
-        fatalError("Not yet implemented")
+        realtime.clientId ?? "AblyTest"
     }
 }
 
@@ -108,7 +108,10 @@ actor MockMessages: Messages {
                 text: MockStrings.randomPhrase(),
                 createdAt: Date(),
                 metadata: [:],
-                headers: [:]
+                headers: [:],
+                version: "",
+                timestamp: Date(),
+                operation: nil
             )
         }, interval: 3)
     }
@@ -132,10 +135,21 @@ actor MockMessages: Messages {
             text: params.text,
             createdAt: Date(),
             metadata: params.metadata ?? [:],
-            headers: params.headers ?? [:]
+            headers: params.headers ?? [:],
+            version: "",
+            timestamp: Date(),
+            operation: nil
         )
         mockSubscriptions.emit(message)
         return message
+    }
+
+    func update(newMessage _: Message, description _: String?, metadata _: OperationMetadata?) async throws -> Message {
+        fatalError("Not yet implemented")
+    }
+
+    func delete(message _: Message, params _: DeleteMessageParams) async throws -> Message {
+        fatalError("Not yet implemented")
     }
 
     func onDiscontinuity(bufferingPolicy _: BufferingPolicy) -> Subscription<DiscontinuityEvent> {

--- a/Example/AblyChatExample/Mocks/MockRealtime.swift
+++ b/Example/AblyChatExample/Mocks/MockRealtime.swift
@@ -10,7 +10,7 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, Sendable {
     }
 
     var clientId: String? {
-        fatalError("Not implemented")
+        "AblyTest"
     }
 
     let channels = Channels()

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "2e855624caf2790f0086192383ad61e930282bbc7a5da8b08c8dc8e1e986b194",
+  "originHash" : "f828ffcb0d1ca3449a984ac4d5096d3e92e6ec875e498549533480ed22dc812d",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "6239f6d5caacbff91e28e9a5c56f8a0f3cc1b662",
-        "version" : "1.2.39"
+        "revision" : "c5347707e4f9fb907df0e5c334de445899a79783",
+        "version" : "1.2.40"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.39"
+            from: "1.2.40"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -73,7 +73,10 @@ public actor DefaultChatClient: ChatClient {
     }
 
     public nonisolated var clientID: String {
-        fatalError("Not yet implemented")
+        guard let clientID = realtime.clientId else {
+            fatalError("Ensure your Realtime instance is initialized with a clientId.")
+        }
+        return clientID
     }
 }
 

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -8,15 +8,19 @@ public enum MessageAction: String, Sendable {
      * Action applied to a new message.
      */
     case create = "message.create"
+    case update = "message.update"
+    case delete = "message.delete"
 
     internal static func fromRealtimeAction(_ action: ARTMessageAction) -> Self? {
         switch action {
         case .create:
             .create
+        case .update:
+            .update
+        case .delete:
+            .delete
         // ignore any other actions except `message.create` for now
-        case .update,
-             .delete,
-             .metaOccupancy,
+        case .metaOccupancy,
              .messageSummary:
             nil
         @unknown default:

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -11,6 +11,11 @@ public typealias MessageHeaders = Headers
 public typealias MessageMetadata = Metadata
 
 /**
+ * ``Metadata`` type used for the metadata within an operation e.g. updating or deleting a message
+ */
+public typealias OperationMetadata = Metadata
+
+/**
  * Represents a single message in a chat room.
  */
 public struct Message: Sendable, Identifiable, Equatable {
@@ -77,7 +82,24 @@ public struct Message: Sendable, Identifiable, Equatable {
      */
     public var headers: MessageHeaders
 
-    public init(serial: String, action: MessageAction, clientID: String, roomID: String, text: String, createdAt: Date?, metadata: MessageMetadata, headers: MessageHeaders) {
+    // (CHA-M10a)
+    /**
+     * A unique identifier for the latest version of this message.
+     */
+    public var version: String
+
+    /**
+     * The timestamp at which this version was updated, deleted, or created.
+     */
+    public var timestamp: Date?
+
+    /**
+     * The details of the operation that modified the message. This is only set for update and delete actions. It contains
+     * information about the operation: the clientId of the user who performed the operation, a description, and metadata.
+     */
+    public var operation: MessageOperation?
+
+    public init(serial: String, action: MessageAction, clientID: String, roomID: String, text: String, createdAt: Date?, metadata: MessageMetadata, headers: MessageHeaders, version: String, timestamp: Date?, operation: MessageOperation? = nil) {
         self.serial = serial
         self.action = action
         self.clientID = clientID
@@ -86,11 +108,46 @@ public struct Message: Sendable, Identifiable, Equatable {
         self.createdAt = createdAt
         self.metadata = metadata
         self.headers = headers
+        self.version = version
+        self.timestamp = timestamp
+        self.operation = operation
     }
+
+    /**
+      * Helper function to copy a message with updated values. This is useful when updating a message e.g. `room().messages.update(newMessage: messageCopy...)`.
+      * If metadata/headers are not provided, it keeps the metadata/headers from the original message.
+      * If metadata/headers are explicitly passed in, the new `Message` will have these values. You can set them to `[:]` if you wish to remove them.
+     */
+    public func copy(
+        text: String? = nil,
+        metadata: MessageMetadata? = nil,
+        headers: MessageHeaders? = nil
+    ) -> Message {
+        Message(
+            serial: serial,
+            action: action,
+            clientID: clientID,
+            roomID: roomID,
+            text: text ?? self.text,
+            createdAt: createdAt,
+            metadata: metadata ?? self.metadata,
+            headers: headers ?? self.headers,
+            version: version,
+            timestamp: timestamp,
+            operation: operation
+        )
+    }
+}
+
+public struct MessageOperation: Sendable, Equatable {
+    public var clientID: String
+    public var description: String?
+    public var metadata: MessageMetadata?
 }
 
 extension Message: JSONObjectDecodable {
     internal init(jsonObject: [String: JSONValue]) throws {
+        let operation = try? jsonObject.objectValueForKey("operation")
         try self.init(
             serial: jsonObject.stringValueForKey("serial"),
             action: jsonObject.rawRepresentableValueForKey("action"),
@@ -99,7 +156,16 @@ extension Message: JSONObjectDecodable {
             text: jsonObject.stringValueForKey("text"),
             createdAt: jsonObject.optionalAblyProtocolDateValueForKey("createdAt"),
             metadata: jsonObject.objectValueForKey("metadata"),
-            headers: jsonObject.objectValueForKey("headers").mapValues { try .init(jsonValue: $0) }
+            headers: jsonObject.objectValueForKey("headers").mapValues { try .init(jsonValue: $0) },
+            version: jsonObject.stringValueForKey("version"),
+            timestamp: jsonObject.optionalAblyProtocolDateValueForKey("timestamp"),
+            operation: operation.map { op in
+                try .init(
+                    clientID: op.stringValueForKey("clientId"),
+                    description: try? op.stringValueForKey("description"),
+                    metadata: try? op.objectValueForKey("metadata")
+                )
+            }
         )
     }
 }

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -40,11 +40,42 @@ public protocol Messages: AnyObject, Sendable, EmitsDiscontinuities {
      * - Parameters:
      *   - params: An object containing `text`, `headers` and `metadata` for the message.
      *
-     * - Returns: The published message.
+     * - Returns: The published message, with the action of the message set as `.create`.
      *
      * - Note: It is possible to receive your own message via the messages subscription before this method returns.
      */
     func send(params: SendMessageParams) async throws -> Message
+
+    /**
+     * Updates a message in the chat room.
+     *
+     * This method uses the Ably Chat API endpoint for updating messages.
+     *
+     * - Parameters:
+     *   - newMessage: A copy of the `Message` object with the intended edits applied. Use the provided `copy` method on the existing message.
+     *   - description: Optional description of the update action.
+     *   - metadata: Optional metadata of the update action. (The metadata of the message itself still resides within the newMessage object above).
+     *
+     * - Returns: The updated message, with the `action` of the message set as `.update`.
+     *
+     * - Note: It is possible to receive your own message via the messages subscription before this method returns.
+     */
+    func update(newMessage: Message, description: String?, metadata: OperationMetadata?) async throws -> Message
+
+    /**
+     * Deletes a message in the chat room.
+     *
+     * This method uses the Ably Chat API endpoint for deleting messages.
+     *
+     * - Parameters:
+     *   - message: The message you wish to delete.
+     *   - params: Contains an optional description and metadata of the delete action.
+     *
+     * - Returns: The deleted message, with the action of the message set as `.delete`.
+     *
+     * - Note: It is possible to receive your own message via the messages subscription before this method returns.
+     */
+    func delete(message: Message, params: DeleteMessageParams) async throws -> Message
 
     /**
      * Get the underlying Ably realtime channel used for the messages in this chat room.
@@ -104,6 +135,56 @@ public struct SendMessageParams: Sendable {
         self.text = text
         self.metadata = metadata
         self.headers = headers
+    }
+}
+
+/**
+ * Params for updating a text message.  All fields are updated and, if omitted, they are set to empty.
+ */
+public struct UpdateMessageParams: Sendable {
+    /**
+     * The params to update including the text of the message.
+     */
+    public var message: SendMessageParams
+
+    /**
+     * Optional description of the update action.
+     */
+    public var description: String?
+
+    /**
+     * Optional metadata of the update action.
+     *
+     * The metadata is a map of extra information that can be attached to the update action.
+     * It is not used by Ably and is sent as part of the realtime
+     * message payload. Example use cases are setting custom styling like
+     * background or text colors or fonts, adding links to external images,
+     * emojis, etc.
+     *
+     * Do not use metadata for authoritative information. There is no server-side
+     * validation. When reading the metadata treat it like user input.
+     *
+     */
+    public var metadata: OperationMetadata?
+
+    public init(message: SendMessageParams, description: String? = nil, metadata: OperationMetadata? = nil) {
+        self.message = message
+        self.description = description
+        self.metadata = metadata
+    }
+}
+
+/**
+ * Params for deleting a message.
+ */
+public struct DeleteMessageParams: Sendable {
+    public var description: String?
+
+    public var metadata: OperationMetadata?
+
+    public init(description: String? = nil, metadata: OperationMetadata? = nil) {
+        self.description = description
+        self.metadata = metadata
     }
 }
 

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -47,7 +47,9 @@ struct ChatAPITests {
             text: "hello",
             createdAt: Date(timeIntervalSince1970: 1_631_840_000),
             metadata: [:],
-            headers: [:]
+            headers: [:],
+            version: "3446456",
+            timestamp: Date(timeIntervalSince1970: 1_631_840_000)
         )
         #expect(message == expectedMessage)
     }
@@ -143,7 +145,9 @@ struct ChatAPITests {
                     text: "hello",
                     createdAt: .init(timeIntervalSince1970: 1_730_943_049.269),
                     metadata: [:],
-                    headers: [:]
+                    headers: [:],
+                    version: "3446456",
+                    timestamp: Date(timeIntervalSince1970: 1_730_943_049.269)
                 ),
                 Message(
                     serial: "3446457",
@@ -153,7 +157,9 @@ struct ChatAPITests {
                     text: "hello response",
                     createdAt: nil,
                     metadata: [:],
-                    headers: [:]
+                    headers: [:],
+                    version: "3446457",
+                    timestamp: nil
                 ),
             ]
         )

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -89,7 +89,9 @@ struct DefaultMessagesTests {
                 ],
                 extras: [
                     "headers": ["numberKey": 10, "stringKey": "hello"],
-                ]
+                ],
+                operation: nil,
+                version: ""
             )
         )
         let featureChannel = MockFeatureChannel(channel: channel)
@@ -122,7 +124,9 @@ struct DefaultMessagesTests {
                     "text": "", // arbitrary
                     "metadata": ["numberKey": 10, "stringKey": "hello"],
                 ],
-                extras: [:]
+                extras: [:],
+                operation: nil,
+                version: ""
             )
         )
         let featureChannel = MockFeatureChannel(channel: channel)

--- a/Tests/AblyChatTests/MessageSubscriptionTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionTests.swift
@@ -26,7 +26,7 @@ private final class MockPaginatedResult<T: Equatable>: PaginatedResult {
 
 struct MessageSubscriptionTests {
     let messages = ["First", "Second"].map { text in
-        Message(serial: "", action: .create, clientID: "", roomID: "", text: text, createdAt: .init(), metadata: [:], headers: [:])
+        Message(serial: "", action: .create, clientID: "", roomID: "", text: text, createdAt: .init(), metadata: [:], headers: [:], version: "", timestamp: nil)
     }
 
     @Test

--- a/Tests/AblyChatTests/MessageTests.swift
+++ b/Tests/AblyChatTests/MessageTests.swift
@@ -10,7 +10,9 @@ struct MessageTests {
         text: "hello",
         createdAt: nil,
         metadata: [:],
-        headers: [:]
+        headers: [:],
+        version: "ABC123@1631840000000-5:2",
+        timestamp: nil
     )
 
     let laterMessage = Message(
@@ -21,7 +23,9 @@ struct MessageTests {
         text: "hello",
         createdAt: nil,
         metadata: [:],
-        headers: [:]
+        headers: [:],
+        version: "ABC123@1631840000000-5:2",
+        timestamp: nil
     )
 
     let invalidMessage = Message(
@@ -32,7 +36,9 @@ struct MessageTests {
         text: "hello",
         createdAt: nil,
         metadata: [:],
-        headers: [:]
+        headers: [:],
+        version: "invalid",
+        timestamp: nil
     )
 
     // MARK: isBefore Tests
@@ -76,7 +82,9 @@ struct MessageTests {
             text: "",
             createdAt: nil,
             metadata: [:],
-            headers: [:]
+            headers: [:],
+            version: "ABC123@1631840000000-5:2",
+            timestamp: nil
         )
         #expect(earlierMessage.serial == duplicateOfEarlierMessage.serial)
     }

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -105,6 +105,8 @@ extension MockHTTPPaginatedResponse {
                 "text": "hello",
                 "metadata": [:],
                 "headers": [:],
+                "version": "3446456",
+                "timestamp": 1_730_943_049_269,
             ],
             [
                 "clientId": "random",
@@ -114,6 +116,7 @@ extension MockHTTPPaginatedResponse {
                 "text": "hello response",
                 "metadata": [:],
                 "headers": [:],
+                "version": "3446457",
             ],
         ],
         statusCode: 200,

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -22,6 +22,8 @@ final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
         var clientID: String
         var data: Any
         var extras: NSDictionary
+        var operation: ARTMessageOperation?
+        var version: String
     }
 
     init(
@@ -147,6 +149,8 @@ final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
             message.serial = messageToEmitOnSubscribe.serial
             message.clientId = messageToEmitOnSubscribe.clientID
             message.extras = messageToEmitOnSubscribe.extras
+            message.operation = messageToEmitOnSubscribe.operation
+            message.version = messageToEmitOnSubscribe.version
             callback(message)
         }
         return ARTEventListener()


### PR DESCRIPTION
Updates the public API to allow users to edit and delete their messages. 

Example app will be updated in a following PR. Additional unit tests will be added after https://github.com/ably/ably-chat-swift/pull/219 is merged. Integration tests have been extended adequately until this is done. 

API differs between edit and delete due to this conversation... https://ably-real-time.slack.com/archives/C02NY1VT3LY/p1740391041340959   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability for users to update and delete messages, allowing for real-time corrections and removals.
  - Enhanced message details with new tracking data, including versioning and timestamps, improving consistency and visibility of changes.

- **Chores**
  - Updated underlying dependencies to the latest release for improved stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->