### PR TITLE
[ECO-5232] Updates Chat client options name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The following features have been added in this release:
 
 The included example app has been updated to demonstrate the new features.
 
+#### Breaking Changes
+
+- Renames `ClientOptions` within this SDK to `ChatClientOptions` (https://github.com/ably/ably-chat-swift/pull/230)
+
 **Full Changelog**: https://github.com/ably/ably-chat-swift/compare/0.1.2...0.2.0
 
 ## [0.1.2](https://github.com/ably/ably-chat-swift/tree/0.1.2)

--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -17,7 +17,7 @@ private enum Environment: Equatable {
         case .mock:
             return MockChatClient(
                 realtime: MockRealtime(),
-                clientOptions: ClientOptions()
+                clientOptions: ChatClientOptions()
             )
         case let .live(key: key, clientId: clientId):
             let realtimeOptions = ARTClientOptions()

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -3,11 +3,11 @@ import AblyChat
 
 actor MockChatClient: ChatClient {
     let realtime: RealtimeClient
-    nonisolated let clientOptions: ClientOptions
+    nonisolated let clientOptions: ChatClientOptions
     nonisolated let rooms: Rooms
     nonisolated let connection: Connection
 
-    init(realtime: RealtimeClient, clientOptions: ClientOptions?) {
+    init(realtime: RealtimeClient, clientOptions: ChatClientOptions?) {
         self.realtime = realtime
         self.clientOptions = clientOptions ?? .init()
         connection = MockConnection(status: .connected, error: nil)
@@ -20,7 +20,7 @@ actor MockChatClient: ChatClient {
 }
 
 actor MockRooms: Rooms {
-    let clientOptions: ClientOptions
+    let clientOptions: ChatClientOptions
     private var rooms = [String: MockRoom]()
 
     func get(roomID: String, options: RoomOptions) async throws -> any Room {
@@ -36,7 +36,7 @@ actor MockRooms: Rooms {
         fatalError("Not yet implemented")
     }
 
-    init(clientOptions: ClientOptions) {
+    init(clientOptions: ChatClientOptions) {
         self.clientOptions = clientOptions
     }
 }

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -35,7 +35,7 @@ public protocol ChatClient: AnyObject, Sendable {
      *
      * - Returns: The client options.
      */
-    var clientOptions: ClientOptions { get }
+    var clientOptions: ChatClientOptions { get }
 }
 
 public typealias RealtimeClient = any RealtimeClientProtocol
@@ -45,7 +45,7 @@ public typealias RealtimeClient = any RealtimeClientProtocol
  */
 public actor DefaultChatClient: ChatClient {
     public nonisolated let realtime: RealtimeClient
-    public nonisolated let clientOptions: ClientOptions
+    public nonisolated let clientOptions: ChatClientOptions
     public nonisolated let rooms: Rooms
     private let logger: InternalLogger
 
@@ -60,7 +60,7 @@ public actor DefaultChatClient: ChatClient {
      *   - realtime: The Ably Realtime client.
      *   - clientOptions: The client options.
      */
-    public init(realtime suppliedRealtime: any SuppliedRealtimeClientProtocol, clientOptions: ClientOptions?) {
+    public init(realtime suppliedRealtime: any SuppliedRealtimeClientProtocol, clientOptions: ChatClientOptions?) {
         self.realtime = suppliedRealtime
         self.clientOptions = clientOptions ?? .init()
 
@@ -83,7 +83,7 @@ public actor DefaultChatClient: ChatClient {
 /**
  * Configuration options for the chat client.
  */
-public struct ClientOptions: Sendable {
+public struct ChatClientOptions: Sendable {
     /**
      * A custom log handler that will be used to log messages from the client.
      *
@@ -104,7 +104,7 @@ public struct ClientOptions: Sendable {
     }
 
     /// Used for comparing these instances in tests without having to make this Equatable, which I’m not yet sure makes sense (we’ll decide in https://github.com/ably-labs/ably-chat-swift/issues/10)
-    internal func isEqualForTestPurposes(_ other: ClientOptions) -> Bool {
+    internal func isEqualForTestPurposes(_ other: ChatClientOptions) -> Bool {
         logHandler === other.logHandler && logLevel == other.logLevel
     }
 }

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -47,7 +47,7 @@ public protocol Rooms: AnyObject, Sendable {
      *
      * - Returns: ``ClientOptions`` object.
      */
-    var clientOptions: ClientOptions { get }
+    var clientOptions: ChatClientOptions { get }
 }
 
 internal actor DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
@@ -60,7 +60,7 @@ internal actor DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
         }
     #endif
 
-    internal nonisolated let clientOptions: ClientOptions
+    internal nonisolated let clientOptions: ChatClientOptions
 
     private let logger: InternalLogger
     private let roomFactory: RoomFactory
@@ -115,7 +115,7 @@ internal actor DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
     /// The value for a given room ID is the state that corresponds to that room ID.
     private var roomStates: [String: RoomState] = [:]
 
-    internal init(realtime: RealtimeClient, clientOptions: ClientOptions, logger: InternalLogger, roomFactory: RoomFactory) {
+    internal init(realtime: RealtimeClient, clientOptions: ChatClientOptions, logger: InternalLogger, roomFactory: RoomFactory) {
         self.realtime = realtime
         self.clientOptions = clientOptions
         self.logger = logger

--- a/Tests/AblyChatTests/DefaultChatClientTests.swift
+++ b/Tests/AblyChatTests/DefaultChatClientTests.swift
@@ -11,7 +11,7 @@ struct DefaultChatClientTests {
         )
 
         // Then: It uses the default client options
-        let defaultOptions = ClientOptions()
+        let defaultOptions = ChatClientOptions()
         #expect(client.clientOptions.isEqualForTestPurposes(defaultOptions))
     }
 
@@ -19,7 +19,7 @@ struct DefaultChatClientTests {
     func test_realtime() {
         // Given: An instance of DefaultChatClient
         let realtime = MockRealtime(createWrapperSDKProxyReturnValue: .init())
-        let options = ClientOptions()
+        let options = ChatClientOptions()
         let client = DefaultChatClient(realtime: realtime, clientOptions: options)
 
         // Then: Its `realtime` property returns the client that was passed to the initializer (i.e. as opposed to the proxy client created by `createWrapperSDKProxy(with:)`
@@ -31,7 +31,7 @@ struct DefaultChatClientTests {
     @Test
     func createsWrapperSDKProxyRealtimeClientWithAgents() throws {
         let realtime = MockRealtime(createWrapperSDKProxyReturnValue: .init())
-        let options = ClientOptions()
+        let options = ChatClientOptions()
         _ = DefaultChatClient(realtime: realtime, clientOptions: options)
 
         #expect(realtime.createWrapperSDKProxyOptionsArgument?.agents == ["chat-swift": AblyChat.version])
@@ -43,7 +43,7 @@ struct DefaultChatClientTests {
         // Given: An instance of DefaultChatClient
         let proxyClient = MockRealtime()
         let realtime = MockRealtime(createWrapperSDKProxyReturnValue: proxyClient)
-        let options = ClientOptions()
+        let options = ChatClientOptions()
         let client = DefaultChatClient(realtime: realtime, clientOptions: options)
 
         // Then: Its `rooms` property returns an instance of DefaultRooms with the wrapper SDK proxy realtime client and same client options

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -47,7 +47,7 @@ struct IntegrationTests {
 
     private static func createSandboxChatClient(apiKey: String, loggingLabel: String) -> DefaultChatClient {
         let realtime = createSandboxRealtime(apiKey: apiKey, loggingLabel: loggingLabel)
-        let clientOptions = TestLogger.loggingEnabled ? ClientOptions(logHandler: ChatLogger(label: loggingLabel), logLevel: .trace) : nil
+        let clientOptions = TestLogger.loggingEnabled ? ChatClientOptions(logHandler: ChatLogger(label: loggingLabel), logLevel: .trace) : nil
 
         return DefaultChatClient(realtime: realtime, clientOptions: clientOptions)
     }


### PR DESCRIPTION
Updates Chat client options name to prevent clashes with ably-coca client options naming in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized the chat client configuration options across public interfaces for a more consistent setup.
  - Renamed `ClientOptions` to `ChatClientOptions` throughout the SDK.

- **Tests**
  - Updated test cases to align with the new configuration option adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->