### PR TITLE
[ECO-5251] Presence tests (single channel)

### DIFF
--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -12,9 +12,9 @@ internal protocol RoomLifecycleManager: Sendable {
     ///
     /// Implements the checks described by CHA-PR3d, CHA-PR3e, and CHA-PR3h (and similar ones described by other functionality that performs channel presence operations). Namely:
     ///
-    /// - CHA-RL9, which is invoked by CHA-PR3d, CHA-PR10d, CHA-PR6c, CHA-T2c: If the room is in the ATTACHING status, it waits for the next room status change. If the new status is ATTACHED, it returns. Else, it throws an `ARTErrorInfo` derived from ``ChatError/roomTransitionedToInvalidStateForPresenceOperation(cause:)``.
-    /// - CHA-PR3e, CHA-PR10e, CHA-PR6d, CHA-T2d: If the room is in the ATTACHED status, it returns immediately.
-    /// - CHA-PR3h, CHA-PR10h, CHA-PR6h, CHA-T2g: If the room is in any other status, it throws an `ARTErrorInfo` derived from ``ChatError/presenceOperationRequiresRoomAttach(feature:)``.
+    /// - CHA-RL9, which is invoked by CHA-PR3d, CHA-PR10d, CHA-PR6c: If the room is in the ATTACHING status, it waits for the next room status change. If the new status is ATTACHED, it returns. Else, it throws an `ARTErrorInfo` derived from ``ChatError/roomTransitionedToInvalidStateForPresenceOperation(cause:)``.
+    /// - CHA-PR3e, CHA-PR10e, CHA-PR6d: If the room is in the ATTACHED status, it returns immediately.
+    /// - CHA-PR3h, CHA-PR10h, CHA-PR6h: If the room is in any other status, it throws an `ARTErrorInfo` derived from ``ChatError/presenceOperationRequiresRoomAttach(feature:)``.
     ///
     /// - Parameters:
     ///   - requester: The room feature that wishes to perform a presence operation. This is only used for customising the message of the thrown error.

--- a/Tests/AblyChatTests/DefaultPresenceTests.swift
+++ b/Tests/AblyChatTests/DefaultPresenceTests.swift
@@ -485,4 +485,6 @@ struct DefaultPresenceTests {
         #expect(leaveEvent.action == .leave)
         #expect(leaveEvent.clientID == "client1")
     }
+
+    // @specNotApplicable CHA-PR7c - Untestable due to `AsyncSequence` subscription used which is removed once the object is removed from memory.
 }

--- a/Tests/AblyChatTests/DefaultPresenceTests.swift
+++ b/Tests/AblyChatTests/DefaultPresenceTests.swift
@@ -1,3 +1,488 @@
+import Ably
+@testable import AblyChat
+import Testing
+
 struct DefaultPresenceTests {
-    // @specUntested CHA-PR7d - We chose to implement this failure with an idiomatic fatalError instead of throwing, but we can’t test this.
+    // MARK: CHA-PR3
+
+    // @spec CHA-PR3a
+    // @specOneOf(2/2) CHA-PR3e
+    @Test
+    func usersMayEnterPresence() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: MockRoomLifecycleManager(),
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        try await defaultPresence.enter(data: ["status": "Online"])
+
+        // Then
+        #expect(channel.presence.callRecorder.hasRecord(
+            matching: "enterClient(_:data:)",
+            arguments: ["name": "client1", "data": JSONValue.object(["userCustomData": ["status": "Online"]])]
+        )
+        )
+    }
+
+    // @specOneOf(3/4) CHA-PR3d
+    @Test
+    func usersMayEnterPresenceWhileAttaching() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        try await defaultPresence.enter()
+
+        // Then
+        #expect(roomLifecycleManager.callRecorder.hasRecord(
+            matching: "waitToBeAbleToPerformPresenceOperations(requestedByFeature:)",
+            arguments: ["requestedByFeature": "presence"]
+        )
+        )
+    }
+
+    // @specOneOf(4/4) CHA-PR3d
+    @Test
+    func usersMayEnterPresenceWhileAttachingWithFailure() async throws {
+        // Given
+        let attachError = ARTErrorInfo(domain: "SomeDomain", code: 123)
+        let error = ARTErrorInfo(chatError: .roomTransitionedToInvalidStateForPresenceOperation(cause: attachError))
+
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager(resultOfWaitToBeAbleToPerformPresenceOperations: .failure(error))
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
+        let doIt = {
+            // When
+            try await defaultPresence.enter()
+        }
+        await #expect {
+            try await doIt()
+        } /* Then */ throws: { error in
+            isChatError(error, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 500), cause: attachError)
+        }
+
+        // Then
+        #expect(roomLifecycleManager.callRecorder.hasRecord(
+            matching: "waitToBeAbleToPerformPresenceOperations(requestedByFeature:)",
+            arguments: ["requestedByFeature": "presence"]
+        )
+        )
+    }
+
+    // @specOneOf(2/2) CHA-PR3h
+    @Test
+    func failToEnterPresenceWhenRoomInInvalidState() async throws {
+        // Given
+        let error = ARTErrorInfo(chatError: .presenceOperationRequiresRoomAttach(feature: .presence))
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager(resultOfWaitToBeAbleToPerformPresenceOperations: .failure(error))
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // Then
+        // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
+        let doIt = {
+            _ = try await defaultPresence.enter()
+        }
+        await #expect {
+            try await doIt()
+        } throws: { error in
+            isChatError(error, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 400))
+        }
+    }
+
+    // MARK: CHA-PR10
+
+    // @spec CHA-PR10a
+    // @specOneOf(2/2) CHA-PR10e
+    @Test
+    func usersMayUpdatePresence() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+        // When
+        try await defaultPresence.update(data: ["status": "Online"])
+
+        // Then
+        #expect(channel.presence.callRecorder.hasRecord(
+            matching: "update(_:)",
+            arguments: ["data": JSONValue.object(["userCustomData": ["status": "Online"]])]
+        )
+        )
+    }
+
+    // @specOneOf(3/4) CHA-PR10d
+    @Test
+    func usersMayUpdatePresenceWhileAttaching() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        try await defaultPresence.update()
+
+        // Then
+        #expect(roomLifecycleManager.callRecorder.hasRecord(
+            matching: "waitToBeAbleToPerformPresenceOperations(requestedByFeature:)",
+            arguments: ["requestedByFeature": "presence"]
+        )
+        )
+    }
+
+    // @specOneOf(4/4) CHA-PR10d
+    @Test
+    func usersMayUpdatePresenceWhileAttachingWithFailure() async throws {
+        // Given
+        let attachError = ARTErrorInfo(domain: "SomeDomain", code: 123)
+        let error = ARTErrorInfo(chatError: .roomTransitionedToInvalidStateForPresenceOperation(cause: attachError))
+
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager(resultOfWaitToBeAbleToPerformPresenceOperations: .failure(error))
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
+        let doIt = {
+            // When
+            try await defaultPresence.update()
+        }
+        await #expect {
+            try await doIt()
+        } /* Then */ throws: { error in
+            isChatError(error, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 500), cause: attachError)
+        }
+
+        // Then
+        #expect(roomLifecycleManager.callRecorder.hasRecord(
+            matching: "waitToBeAbleToPerformPresenceOperations(requestedByFeature:)",
+            arguments: ["requestedByFeature": "presence"]
+        )
+        )
+    }
+
+    // @specOneOf(2/2) CHA-PR10h
+    @Test
+    func failToUpdatePresenceWhenRoomInInvalidState() async throws {
+        // Given
+        let error = ARTErrorInfo(chatError: .presenceOperationRequiresRoomAttach(feature: .presence))
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager(resultOfWaitToBeAbleToPerformPresenceOperations: .failure(error))
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // Then
+        // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
+        let doIt = {
+            _ = try await defaultPresence.update()
+        }
+        await #expect {
+            try await doIt()
+        } throws: { error in
+            isChatError(error, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 400))
+        }
+    }
+
+    // MARK: CHA-PR4
+
+    // @spec CHA-PR4a
+    @Test
+    func usersMayLeavePresence() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        try await defaultPresence.leave()
+
+        // Then
+        #expect(channel.presence.callRecorder.hasRecord(
+            matching: "leave(_:)",
+            arguments: ["data": JSONValue.object([:])]
+        )
+        )
+    }
+
+    // MARK: CHA-PR5
+
+    // @spec CHA-PR5
+    @Test
+    func ifUserIsPresent() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        _ = try await defaultPresence.isUserPresent(clientID: "client1")
+
+        // Then
+        #expect(channel.presence.callRecorder.hasRecord(
+            matching: "get(_:)",
+            arguments: ["query": "\(ARTRealtimePresenceQuery(clientId: "client1", connectionId: "").callRecorderDescription)"]
+        )
+        )
+    }
+
+    // MARK: CHA-PR6
+
+    // @spec CHA-PR6
+    // @specOneOf(2/2) CHA-PR6d
+    @Test
+    func retrieveAllTheMembersOfThePresenceSet() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        _ = try await defaultPresence.get()
+
+        // Then
+        #expect(channel.presence.callRecorder.hasRecord(
+            matching: "get()",
+            arguments: [:]
+        )
+        )
+    }
+
+    // @specOneOf(2/2) CHA-PR6h
+    @Test
+    func failToRetrieveAllTheMembersOfThePresenceSetWhenRoomInInvalidState() async throws {
+        // Given
+        let error = ARTErrorInfo(chatError: .presenceOperationRequiresRoomAttach(feature: .presence))
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager(resultOfWaitToBeAbleToPerformPresenceOperations: .failure(error))
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // Then
+        // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
+        let doIt = {
+            _ = try await defaultPresence.get()
+        }
+        await #expect {
+            try await doIt()
+        } throws: { error in
+            isChatError(error, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 400))
+        }
+    }
+
+    // @specOneOf(3/4) CHA-PR6c
+    @Test
+    func retrieveAllTheMembersOfThePresenceSetWhileAttaching() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        _ = try await defaultPresence.get()
+
+        // Then
+        #expect(roomLifecycleManager.callRecorder.hasRecord(
+            matching: "waitToBeAbleToPerformPresenceOperations(requestedByFeature:)",
+            arguments: ["requestedByFeature": "presence"]
+        )
+        )
+    }
+
+    // @specOneOf(4/4) CHA-PR6c
+    @Test
+    func retrieveAllTheMembersOfThePresenceSetWhileAttachingWithFailure() async throws {
+        // Given
+        let attachError = ARTErrorInfo(domain: "SomeDomain", code: 123)
+        let error = ARTErrorInfo(chatError: .roomTransitionedToInvalidStateForPresenceOperation(cause: attachError))
+
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager(resultOfWaitToBeAbleToPerformPresenceOperations: .failure(error))
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
+        let doIt = {
+            // When
+            try await defaultPresence.get()
+        }
+        await #expect {
+            try await doIt()
+        } /* Then */ throws: { error in
+            isChatError(error, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 500), cause: attachError)
+        }
+
+        // Then
+        #expect(roomLifecycleManager.callRecorder.hasRecord(
+            matching: "waitToBeAbleToPerformPresenceOperations(requestedByFeature:)",
+            arguments: ["requestedByFeature": "presence"]
+        )
+        )
+    }
+
+    // MARK: CHA-PR7
+
+    // @spec CHA-PR7a
+    // @spec CHA-PR7b
+    @Test
+    func usersMaySubscribeToAllPresenceEvents() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let roomLifecycleManager = await MockRoomLifecycleManager()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: roomLifecycleManager,
+            roomID: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // Given
+        let subscription = await defaultPresence.subscribe(events: .all) // CHA-PR7a and CHA-PR7b since `all` is just a selection of all events
+
+        // When
+        subscription.emit(PresenceEvent(action: .present, clientID: "client1", timestamp: Date(), data: nil))
+
+        // Then
+        let presentEvent = try #require(await subscription.first { _ in true })
+        #expect(presentEvent.action == .present)
+        #expect(presentEvent.clientID == "client1")
+
+        // When
+        subscription.emit(PresenceEvent(action: .enter, clientID: "client1", timestamp: Date(), data: nil))
+
+        // Then
+        let enterEvent = try #require(await subscription.first { _ in true })
+        #expect(enterEvent.action == .enter)
+        #expect(enterEvent.clientID == "client1")
+
+        // When
+        subscription.emit(PresenceEvent(action: .update, clientID: "client1", timestamp: Date(), data: nil))
+
+        // Then
+        let updateEvent = try #require(await subscription.first { _ in true })
+        #expect(updateEvent.action == .update)
+        #expect(updateEvent.clientID == "client1")
+
+        // When
+        subscription.emit(PresenceEvent(action: .leave, clientID: "client1", timestamp: Date(), data: nil))
+
+        // Then
+        let leaveEvent = try #require(await subscription.first { _ in true })
+        #expect(leaveEvent.action == .leave)
+        #expect(leaveEvent.clientID == "client1")
+    }
 }

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -942,9 +942,9 @@ struct DefaultRoomLifecycleManagerTests {
     // @specOneOf(1/2) CHA-RL9a
     // @spec CHA-RL9b
     //
-    // @specPartial CHA-PR3d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR10d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR6c - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
+    // @specOneOf(1/4) CHA-PR3d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
+    // @specOneOf(1/4) CHA-PR10d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
+    // @specOneOf(1/4) CHA-PR6c - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
     @Test
     func waitToBeAbleToPerformPresenceOperations_whenAttaching_whenTransitionsToAttached() async throws {
         // Given: A DefaultRoomLifecycleManager, with an ATTACH operation in progress and hence in the ATTACHING status
@@ -981,9 +981,9 @@ struct DefaultRoomLifecycleManagerTests {
     // @specOneOf(2/2) CHA-RL9a
     // @spec CHA-RL9c
     //
-    // @specPartial CHA-PR3d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR10d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR6c - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
+    // @specOneOf(2/4) CHA-PR3d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
+    // @specOneOf(2/4) CHA-PR10d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
+    // @specOneOf(2/4) CHA-PR6c - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
     @Test
     func waitToBeAbleToPerformPresenceOperations_whenAttaching_whenTransitionsToNonAttachedStatus() async throws {
         // Given: A DefaultRoomLifecycleManager, with an ATTACH operation in progress and hence in the ATTACHING status
@@ -1026,9 +1026,9 @@ struct DefaultRoomLifecycleManagerTests {
         #expect(isChatError(caughtError, withCodeAndStatusCode: .variableStatusCode(.roomInInvalidState, statusCode: 500), cause: expectedCause))
     }
 
-    // @specPartial CHA-PR3e - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR10e - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR6d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect. TODO change this to a specOneOf once the feature is implemented
+    // @specOneOf(1/2) CHA-PR3e - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
+    // @specOneOf(1/2) CHA-PR10e - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
+    // @specOneOf(1/2) CHA-PR6d - Tests the wait described in the spec point, but not that the feature actually performs this wait nor the side effect.
     @Test
     func waitToBeAbleToPerformPresenceOperations_whenAttached() async throws {
         // Given: A DefaultRoomLifecycleManager in the ATTACHED status
@@ -1041,9 +1041,9 @@ struct DefaultRoomLifecycleManagerTests {
         try await manager.waitToBeAbleToPerformPresenceOperations(requestedByFeature: .messages /* arbitrary */ )
     }
 
-    // @specPartial CHA-PR3h - Tests the wait described in the spec point, but not that the feature actually performs this wait. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR10h - Tests the wait described in the spec point, but not that the feature actually performs this wait. TODO change this to a specOneOf once the feature is implemented
-    // @specPartial CHA-PR6h - Tests the wait described in the spec point, but not that the feature actually performs this wait. TODO change this to a specOneOf once the feature is implemented
+    // @specOneOf(1/2) CHA-PR3h - Tests the wait described in the spec point, but not that the feature actually performs this wait.
+    // @specOneOf(1/2) CHA-PR10h - Tests the wait described in the spec point, but not that the feature actually performs this wait.
+    // @specOneOf(1/2) CHA-PR6h - Tests the wait described in the spec point, but not that the feature actually performs this wait.
     @Test
     func waitToBeAbleToPerformPresenceOperations_whenAnyOtherStatus() async throws {
         // Given: A DefaultRoomLifecycleManager in a status other than ATTACHING or ATTACHED

--- a/Tests/AblyChatTests/Helpers/Helpers.swift
+++ b/Tests/AblyChatTests/Helpers/Helpers.swift
@@ -75,3 +75,103 @@ func isInternalErrorWithCase(_ error: any Error, _ expectedCase: InternalError.C
         false
     }
 }
+
+extension ARTPresenceMessage {
+    convenience init(clientId: String, data: Any? = [:], timestamp: Date = Date()) {
+        self.init()
+        self.clientId = clientId
+        self.data = data
+        self.timestamp = timestamp
+    }
+}
+
+extension [PresenceEventType] {
+    static let all = [
+        PresenceEventType.present,
+        PresenceEventType.enter,
+        PresenceEventType.leave,
+        PresenceEventType.update,
+    ]
+}
+
+/// Compares Any to another Any which is unavailable by default in swift for type safety, but useful to have in tests.
+func compareAny(_ any1: Any?, with any2: Any?) -> Bool {
+    guard let any1, let any2 else {
+        return any1 == nil && any2 == nil
+    }
+    if let any1 = any1 as? Int, let any2 = any2 as? Int {
+        return any1 == any2
+    } else if let any1 = any1 as? Bool, let any2 = any2 as? Bool {
+        return any1 == any2
+    } else if let any1 = any1 as? String, let any2 = any2 as? String {
+        return any1 == any2
+    } else if let any1 = any1 as? JSONValue, let any2 = any2 as? JSONValue {
+        return any1 == any2
+    } else if let any1 = any1 as? [String: Any], let any2 = any2 as? [String: Any] {
+        return NSDictionary(dictionary: any1).isEqual(to: any2)
+    } else if let any1 = any1 as? [Any], let any2 = any2 as? [Any] {
+        guard any1.count == any2.count else {
+            return false
+        }
+        for i in 0 ..< any1.count where !compareAny(any1[i], with: any2[i]) {
+            return false
+        }
+        return true
+    }
+    return false
+}
+
+/// A threadsafe mock methods call logger.
+class MockMethodCallRecorder: @unchecked Sendable {
+    struct MethodArgument: Equatable {
+        let name: String
+        let value: Any?
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            guard lhs.name == rhs.name else {
+                return false
+            }
+            return compareAny(lhs.value, with: rhs.value)
+        }
+    }
+
+    struct CallRecord {
+        let signature: String
+        let arguments: [MethodArgument]
+    }
+
+    private var mutex = NSLock()
+    private var records = [CallRecord]()
+
+    func addRecord(signature: String, arguments: [String: Any?]) { // chose Any to not to deal with types in the test's code
+        mutex.withLock {
+            records.append(CallRecord(signature: signature, arguments: arguments.map { MethodArgument(name: $0.key, value: $0.value) }))
+        }
+    }
+
+    func hasRecord(matching signature: String, arguments: [String: Any]) -> Bool {
+        mutex.withLock {
+            records.contains { record in
+                guard record.signature == signature else {
+                    return false
+                }
+                let args1 = record.arguments.sorted()
+                let args2 = arguments.map { MethodArgument(name: $0.key, value: $0.value) }.sorted()
+                return args1 == args2
+            }
+        }
+    }
+}
+
+private extension [MockMethodCallRecorder.MethodArgument] {
+    func sorted() -> [MockMethodCallRecorder.MethodArgument] {
+        sorted { $0.name < $1.name }
+    }
+}
+
+extension [String: Any] {
+    func toAblyCocoaData() -> Any {
+        // Probaly there is a better way of doing this
+        PresenceDataDTO(userCustomData: JSONValue(ablyCocoaData: self)).toJSONValue.toAblyCocoaData
+    }
+}

--- a/Tests/AblyChatTests/Mocks/MockRealtimePresence.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimePresence.swift
@@ -2,16 +2,18 @@ import Ably
 @testable import AblyChat
 
 final class MockRealtimePresence: InternalRealtimePresenceProtocol {
+    let callRecorder = MockMethodCallRecorder()
+
     func subscribe(_: @escaping @MainActor (ARTPresenceMessage) -> Void) -> ARTEventListener? {
-        fatalError("Not implemented")
+        ARTEventListener()
     }
 
     func subscribe(_: ARTPresenceAction, callback _: @escaping @MainActor (ARTPresenceMessage) -> Void) -> ARTEventListener? {
-        fatalError("Not implemented")
+        ARTEventListener()
     }
 
     func unsubscribe(_: ARTEventListener) {
-        fatalError("Not implemented")
+        // no-op since it's called automatically
     }
 
     func leaveClient(_: String, data _: JSONValue?) {
@@ -19,22 +21,45 @@ final class MockRealtimePresence: InternalRealtimePresenceProtocol {
     }
 
     func get() async throws(InternalError) -> [PresenceMessage] {
-        fatalError("Not implemented")
+        callRecorder.addRecord(
+            signature: "get()",
+            arguments: [:]
+        )
+        return []
     }
 
-    func get(_: ARTRealtimePresenceQuery) async throws(InternalError) -> [PresenceMessage] {
-        fatalError("Not implemented")
+    func get(_ query: ARTRealtimePresenceQuery) async throws(InternalError) -> [PresenceMessage] {
+        callRecorder.addRecord(
+            signature: "get(_:)",
+            arguments: ["query": "\(query.callRecorderDescription)"]
+        )
+        return []
     }
 
-    func leave(_: JSONValue?) async throws(InternalError) {
-        fatalError("Not implemented")
+    func leave(_ data: JSONValue?) async throws(InternalError) {
+        callRecorder.addRecord(
+            signature: "leave(_:)",
+            arguments: ["data": data]
+        )
     }
 
-    func enterClient(_: String, data _: JSONValue?) async throws(InternalError) {
-        fatalError("Not implemented")
+    func enterClient(_ name: String, data: JSONValue?) async throws(InternalError) {
+        callRecorder.addRecord(
+            signature: "enterClient(_:data:)",
+            arguments: ["name": name, "data": data]
+        )
     }
 
-    func update(_: JSONValue?) async throws(InternalError) {
-        fatalError("Not implemented")
+    func update(_ data: JSONValue?) async throws(InternalError) {
+        callRecorder.addRecord(
+            signature: "update(_:)",
+            arguments: ["data": data]
+        )
+    }
+}
+
+extension ARTRealtimePresenceQuery {
+    var callRecorderDescription: String {
+        "clientId=\(clientId!)"
     }
 }


### PR DESCRIPTION
Part of #235 

Results of running unit tests 100 times in Xcode:

```
Iteration 100 ended after 0.536 seconds.
Test run with 15300 tests passed after 45.864 seconds.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive asynchronous tests for presence-related chat functionality, including entering, updating, leaving, retrieving, and subscribing to presence events.
- **Tests**
  - Enhanced test mocks with call recording and configurable behavior for presence and room lifecycle operations.
  - Improved test utilities for deep equality checks and presence event handling.
  - Updated test annotations for clearer specification traceability.
- **Chores**
  - Expanded and refined test coverage to ensure robust validation of presence features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->