### PR TITLE
A couple of improvements to the `spec-coverage` tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,11 +126,16 @@ You can run `swift run BuildTool spec-coverage` to generate a report about how m
 In addition to the above, you can add the following as a comment anywhere in the test suite:
 
 - `@specUntested <spec-item-id> - <explanation>` — This indicates that the SDK implements the given spec point, but that there are no automated tests for it. This should be used sparingly; only use it when there is no way to test a spec point. It must be accompanied by an explanation of why this spec point is not tested.
+- `@specNotApplicable <spec-item-id> - <explanation>` — This indicates that the spec item is not relevant for this version of the SDK. It must be accompanied by an explanation of why.
 
 Example:
 
 ```swift
 // @specUntested CHA-EX2b - I was unable to find a way to test this spec point in an environment in which concurrency is being used; there is no obvious moment at which to stop observing the emitted state changes in order to be sure that FAILED has not been emitted twice.
+```
+
+```swift
+// @specNotApplicable CHA-EX3a - Our API does not have a concept of "partial options" unlike the JS API which this spec item considers.
 ```
 
 ## Release process

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -282,6 +282,7 @@ struct SpecCoverage: AsyncParsableCommand {
         case couldNotFindTestTarget
         case malformedSpecOneOfTag
         case specUntestedTagMissingComment
+        case specNotApplicableTagMissingComment
         case specOneOfIncorrectTotals(specPointID: String, coverageTagTotals: [Int], actualTotal: Int)
         case specOneOfIncorrectIndices(specPointID: String, coverageTagIndices: [Int], expectedIndices: [Int])
         case multipleConformanceTagTypes(specPointID: String, types: [String])
@@ -330,12 +331,14 @@ struct SpecCoverage: AsyncParsableCommand {
             case specOneOf(index: Int, total: Int, comment: String?)
             case specPartial(comment: String?)
             case specUntested(comment: String)
+            case specNotApplicable(comment: String)
 
             enum Case {
                 case spec
                 case specOneOf
                 case specPartial
                 case specUntested
+                case specNotApplicable
             }
 
             var `case`: Case {
@@ -348,6 +351,8 @@ struct SpecCoverage: AsyncParsableCommand {
                     .specPartial
                 case .specUntested:
                     .specUntested
+                case .specNotApplicable:
+                    .specNotApplicable
                 }
             }
         }
@@ -356,7 +361,7 @@ struct SpecCoverage: AsyncParsableCommand {
         var specPointID: String
 
         init?(sourceLine: String) throws {
-            let conformanceTagSourceLineRegex = /^\s+\/\/ @spec(OneOf|Partial|Untested)?(?:\((\d)?\/(\d)?\))? (.*?)(?: - (.*))?$/
+            let conformanceTagSourceLineRegex = /^\s+\/\/ @spec(OneOf|Partial|Untested|NotApplicable)?(?:\((\d)?\/(\d)?\))? (.*?)(?: - (.*))?$/
 
             guard let match = try conformanceTagSourceLineRegex.firstMatch(in: sourceLine) else {
                 return nil
@@ -385,6 +390,11 @@ struct SpecCoverage: AsyncParsableCommand {
                     throw Error.specUntestedTagMissingComment
                 }
                 type = .specUntested(comment: comment)
+            case "NotApplicable":
+                guard let comment else {
+                    throw Error.specNotApplicableTagMissingComment
+                }
+                type = .specNotApplicable(comment: comment)
             default:
                 preconditionFailure("Incorrect assumption when reading regex captures")
             }
@@ -433,6 +443,7 @@ struct SpecCoverage: AsyncParsableCommand {
             case partiallyTested
             case implementedButDeliberatelyNotTested
             case notTested
+            case notApplicable
         }
 
         struct SpecPointCoverage {
@@ -505,6 +516,9 @@ struct SpecCoverage: AsyncParsableCommand {
                     }
                 case let .specUntested(comment: comment):
                     coverageLevel = .implementedButDeliberatelyNotTested
+                    comments.append(comment)
+                case let .specNotApplicable(comment: comment):
+                    coverageLevel = .notApplicable
                     comments.append(comment)
                 }
 
@@ -630,6 +644,8 @@ struct SpecCoverage: AsyncParsableCommand {
                 "Implemented, not tested"
             case .notTested:
                 "Not tested"
+            case .notApplicable:
+                "Not applicable"
             }
         }
     }


### PR DESCRIPTION
- Add ability to run against a specific spec commit (will be useful for a couple of features we're currently working on, for which the spec is not yet in `main`)
- Add ability to mark a spec point as not applicable (will need for the upcoming single-channel changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidelines to include a new annotation for marking spec items as not applicable with an accompanying explanation.

- **New Features**
  - Added a command-line option that allows users to specify the spec commit reference manually.
  - Enhanced output messaging and error handling to reflect the use of a user-specified spec commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->