### PR TITLE
Temporarily lock to Xcode < 16.3

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16
+          xcode-version: 16.2
 
       # We use caching for Mint because at the time of writing SwiftLint took about 5 minutes to build in CI, which is unacceptably slow.
       # https://github.com/actions/cache/blob/40c3b67b2955d93d83b27ed164edd0756bc24049/examples.md#swift---mint
@@ -50,7 +50,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16
+          xcode-version: 16.2
 
       - name: Spec coverage
         run: swift run BuildTool spec-coverage
@@ -69,7 +69,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16
+          xcode-version: 16.2
 
       - id: generation-step
         run: swift run BuildTool generate-matrices >> $GITHUB_OUTPUT
@@ -229,7 +229,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16
+          xcode-version: 16.2
 
       # Dry run upload-action to get base-path url
       - name: Dry-Run Upload (to get url)

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -136,7 +136,7 @@ struct GenerateMatrices: ParsableCommand {
     mutating func run() throws {
         let tooling = [
             [
-                "xcodeVersion": "16",
+                "xcodeVersion": "16.2",
             ],
         ]
 


### PR DESCRIPTION
We have build failures in 16.3, which appears to now be the default Xcode version on some (but not all) runner instances. Once it's available on all runner instances, we'll fix these issues in #253.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the Xcode version in the CI/CD pipeline (affecting linting, testing, and documentation workflows) to version 16.2.
	- Updated the build configuration to use Xcode 16.2 in the toolchain matrix for improved environment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->