### PR TITLE
Release version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.3.0](https://github.com/ably/ably-chat-swift/tree/0.3.0)
+
+## What's Changed
+
+- All of the main protocols in the SDK are now marked as `@MainActor`, to simplify the experience of using the SDK. (#261)
+- All of the errors thrown by the SDK are now explicitly typed as `ARTErrorInfo`. (#234)
+
+**Full Changelog**: https://github.com/ably/ably-chat-swift/compare/0.2.0...0.3.0
+
 ## [0.2.0](https://github.com/ably/ably-chat-swift/tree/0.2.0)
 
 ## What's Changed

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -4,6 +4,6 @@ import Ably
 
 // Update this when you release a new version
 // Version information
-internal let version = "0.2.0"
+internal let version = "0.3.0"
 
 internal let agents = ["chat-swift": version]


### PR DESCRIPTION
This was originally intended as a "fix compiler crash in Xcode 16.3" release, but actually it turns out 0.2.0 compiles fine in Xcode 16.3 (since we hadn't yet introduced typed throws). So instead it's now a "`@MainActor` and typed throws" release.

Documentation changes are in https://github.com/ably/docs/pull/2532.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the SDK to version 0.3.0, enhancing overall protocol responsiveness and error clarity.
  
- **Documentation**
  - Improved the release notes with detailed changelog entries and a link to a full version comparison for additional context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->