### PR TITLE
Use typed throws in `getPreviousMessages`

### DIFF
--- a/Sources/AblyChat/InternalError.swift
+++ b/Sources/AblyChat/InternalError.swift
@@ -12,6 +12,7 @@ internal enum InternalError: Error {
         case headersValueJSONDecodingError(HeadersValue.JSONDecodingError)
         case jsonValueDecodingError(JSONValueDecodingError)
         case paginatedResultError(PaginatedResultError)
+        case messagesError(DefaultMessages.MessagesError)
     }
 
     /// Returns the error that this should be converted to when exposed via the SDK's public API.
@@ -57,5 +58,11 @@ internal extension JSONValueDecodingError {
 internal extension PaginatedResultError {
     func toInternalError() -> InternalError {
         .other(.paginatedResultError(self))
+    }
+}
+
+internal extension DefaultMessages.MessagesError {
+    func toInternalError() -> InternalError {
+        .other(.messagesError(self))
     }
 }

--- a/Tests/AblyChatTests/Helpers/Helpers.swift
+++ b/Tests/AblyChatTests/Helpers/Helpers.swift
@@ -47,6 +47,7 @@ extension InternalError {
         case headersValueJSONDecodingError
         case jsonValueDecodingError
         case paginatedResultError
+        case messagesError
     }
 
     var enumCase: Case {
@@ -61,6 +62,8 @@ extension InternalError {
             .jsonValueDecodingError
         case .other(.paginatedResultError):
             .paginatedResultError
+        case .other(.messagesError):
+            .messagesError
         }
     }
 }


### PR DESCRIPTION
Missed this in c09ac03.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in message retrieval and subscription features, resulting in clearer and more consistent error messages for users.
- **Tests**
	- Enhanced test coverage to recognize new error types, ensuring more reliable error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->