### PR TITLE
Improve some names of generic type parameters and associated types

### DIFF
--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -2,13 +2,13 @@ import Ably
 import AblyChat
 
 final class MockMessagesPaginatedResult: PaginatedResult {
-    typealias T = Message
+    typealias Item = Message
 
     let clientID: String
     let roomID: String
     let numberOfMockMessages: Int
 
-    var items: [T] {
+    var items: [Item] {
         Array(repeating: 0, count: numberOfMockMessages).map { _ in
             Message(
                 serial: "\(Date().timeIntervalSince1970)",
@@ -30,11 +30,11 @@ final class MockMessagesPaginatedResult: PaginatedResult {
 
     var isLast: Bool { fatalError("Not implemented") }
 
-    var next: (any PaginatedResult<T>)? { fatalError("Not implemented") }
+    var next: (any PaginatedResult<Item>)? { fatalError("Not implemented") }
 
-    var first: any PaginatedResult<T> { fatalError("Not implemented") }
+    var first: any PaginatedResult<Item> { fatalError("Not implemented") }
 
-    var current: any PaginatedResult<T> { fatalError("Not implemented") }
+    var current: any PaginatedResult<Item> { fatalError("Not implemented") }
 
     init(clientID: String, roomID: String, numberOfMockMessages: Int = 3) {
         self.clientID = clientID

--- a/Example/AblyChatExample/Mocks/MockSubscription.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscription.swift
@@ -2,8 +2,7 @@ import Ably
 import AblyChat
 import AsyncAlgorithms
 
-final class MockSubscription<T: Sendable>: Sendable, AsyncSequence {
-    typealias Element = T
+final class MockSubscription<Element: Sendable>: Sendable, AsyncSequence {
     typealias AsyncTimerMockSequence = AsyncMapSequence<AsyncTimerSequence<ContinuousClock>, Element>
     typealias MockMergedSequence = AsyncMerge2Sequence<AsyncStream<Element>, AsyncTimerMockSequence>
     typealias AsyncIterator = MockMergedSequence.Iterator

--- a/Sources/AblyChat/BufferingPolicy.swift
+++ b/Sources/AblyChat/BufferingPolicy.swift
@@ -1,13 +1,13 @@
 /**
  * Describes what to do with realtime events that come in faster than the consumer of an `AsyncSequence` can handle them.
- * (This is the same as `AsyncStream<T>.Continuation.BufferingPolicy` but with the generic type parameter `T` removed.)
+ * (This is the same as `AsyncStream<Element>.Continuation.BufferingPolicy` but with the generic type parameter `Element` removed.)
  */
 public enum BufferingPolicy: Sendable {
     case unbounded
     case bufferingOldest(Int)
     case bufferingNewest(Int)
 
-    internal func asAsyncStreamBufferingPolicy<T>() -> AsyncStream<T>.Continuation.BufferingPolicy {
+    internal func asAsyncStreamBufferingPolicy<Element>() -> AsyncStream<Element>.Continuation.BufferingPolicy {
         switch self {
         case let .bufferingNewest(count):
             .bufferingNewest(count)

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -296,7 +296,7 @@ public final class MessageSubscription: Sendable, AsyncSequence {
     }
 
     // used for testing
-    public init<T: AsyncSequence & Sendable>(mockAsyncSequence: T, mockGetPreviousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>) where T.Element == Element {
+    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockGetPreviousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>) where Underlying.Element == Element {
         subscription = .init(mockAsyncSequence: mockAsyncSequence)
         getPreviousMessages = { @Sendable params throws(InternalError) in
             do throws(ARTErrorInfo) {

--- a/Sources/AblyChat/PaginatedResult.swift
+++ b/Sources/AblyChat/PaginatedResult.swift
@@ -1,17 +1,17 @@
 import Ably
 
-public protocol PaginatedResult<T>: AnyObject, Sendable, Equatable {
-    associatedtype T
+public protocol PaginatedResult<Item>: AnyObject, Sendable, Equatable {
+    associatedtype Item
 
-    var items: [T] { get }
+    var items: [Item] { get }
     var hasNext: Bool { get }
     var isLast: Bool { get }
     // TODO: (https://github.com/ably-labs/ably-chat-swift/issues/11): consider how to avoid the need for an unwrap
     // Note that there seems to be a compiler bug (https://github.com/swiftlang/swift/issues/79992) that means that the compiler does not enforce the access level of the error type for property getters. I accidentally originally wrote these as throws(InternalError), which the compiler should have rejected since InternalError is internal and this protocol is public, but it did not reject it and this mistake was only noticed in code review.
     // TODO: (https://github.com/ably/ably-chat-swift/issues/267) restore typed throws here once Xcode 16.3 compiler bug fixed
-    var next: (any PaginatedResult<T>)? { get async throws }
-    var first: any PaginatedResult<T> { get async throws }
-    var current: any PaginatedResult<T> { get async throws }
+    var next: (any PaginatedResult<Item>)? { get async throws }
+    var first: any PaginatedResult<Item> { get async throws }
+    var current: any PaginatedResult<Item> { get async throws }
 }
 
 /// Used internally to reduce the amount of duplicate code when interacting with `ARTHTTPPaginatedCallback`'s. The wrapper takes in the callback result from the caller e.g. `realtime.request` and either throws the appropriate error, or decodes and returns the response.
@@ -49,13 +49,13 @@ internal enum PaginatedResultError: Error {
 }
 
 /// `PaginatedResult` protocol implementation allowing access to the underlying items from a lower level paginated response object e.g. `ARTHTTPPaginatedResponse`, whilst succinctly handling errors through the use of `ARTHTTPPaginatedCallbackWrapper`.
-internal final class PaginatedResultWrapper<T: JSONDecodable & Sendable & Equatable>: PaginatedResult {
-    internal let items: [T]
+internal final class PaginatedResultWrapper<Item: JSONDecodable & Sendable & Equatable>: PaginatedResult {
+    internal let items: [Item]
     internal let hasNext: Bool
     internal let isLast: Bool
     internal let paginatedResponse: ARTHTTPPaginatedResponse
 
-    internal init(paginatedResponse: ARTHTTPPaginatedResponse, items: [T]) {
+    internal init(paginatedResponse: ARTHTTPPaginatedResponse, items: [Item]) {
         self.items = items
         hasNext = paginatedResponse.hasNext
         isLast = paginatedResponse.isLast
@@ -63,7 +63,7 @@ internal final class PaginatedResultWrapper<T: JSONDecodable & Sendable & Equata
     }
 
     /// Asynchronously fetch the next page if available
-    internal var next: (any PaginatedResult<T>)? {
+    internal var next: (any PaginatedResult<Item>)? {
         get async throws {
             do {
                 return try await withCheckedContinuation { continuation in
@@ -78,7 +78,7 @@ internal final class PaginatedResultWrapper<T: JSONDecodable & Sendable & Equata
     }
 
     /// Asynchronously fetch the first page
-    internal var first: any PaginatedResult<T> {
+    internal var first: any PaginatedResult<Item> {
         get async throws {
             do {
                 return try await withCheckedContinuation { continuation in
@@ -93,11 +93,11 @@ internal final class PaginatedResultWrapper<T: JSONDecodable & Sendable & Equata
     }
 
     /// Asynchronously fetch the current page
-    internal var current: any PaginatedResult<T> {
+    internal var current: any PaginatedResult<Item> {
         self
     }
 
-    internal static func == (lhs: PaginatedResultWrapper<T>, rhs: PaginatedResultWrapper<T>) -> Bool {
+    internal static func == (lhs: PaginatedResultWrapper<Item>, rhs: PaginatedResultWrapper<Item>) -> Bool {
         lhs.items == rhs.items &&
             lhs.hasNext == rhs.hasNext &&
             lhs.isLast == rhs.isLast &&
@@ -107,7 +107,7 @@ internal final class PaginatedResultWrapper<T: JSONDecodable & Sendable & Equata
 
 internal extension ARTHTTPPaginatedResponse {
     /// Converts an `ARTHTTPPaginatedResponse` to a `PaginatedResultWrapper` allowing for access to operations as per conformance to `PaginatedResult`.
-    func toPaginatedResult<T: JSONDecodable & Sendable>(items: [T]) -> PaginatedResultWrapper<T> {
+    func toPaginatedResult<Item: JSONDecodable & Sendable>(items: [Item]) -> PaginatedResultWrapper<Item> {
         PaginatedResultWrapper(paginatedResponse: self, items: items)
     }
 }

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -21,7 +21,7 @@ public final class Subscription<Element: Sendable>: @unchecked Sendable, AsyncSe
     fileprivate struct AnyNonThrowingAsyncSequence: AsyncSequence, Sendable {
         private var makeAsyncIteratorImpl: @Sendable () -> AsyncIterator
 
-        init<T: AsyncSequence & Sendable>(asyncSequence: T) where T.Element == Element {
+        init<Underlying: AsyncSequence & Sendable>(asyncSequence: Underlying) where Underlying.Element == Element {
             makeAsyncIteratorImpl = {
                 AsyncIterator(asyncIterator: asyncSequence.makeAsyncIterator())
             }
@@ -30,7 +30,7 @@ public final class Subscription<Element: Sendable>: @unchecked Sendable, AsyncSe
         fileprivate struct AsyncIterator: AsyncIteratorProtocol {
             private var nextImpl: () async -> Element?
 
-            init<T: AsyncIteratorProtocol>(asyncIterator: T) where T.Element == Element {
+            init<Underlying: AsyncIteratorProtocol>(asyncIterator: Underlying) where Underlying.Element == Element {
                 var iterator = asyncIterator
                 nextImpl = { () async -> Element? in
                     do {
@@ -60,7 +60,7 @@ public final class Subscription<Element: Sendable>: @unchecked Sendable, AsyncSe
     }
 
     // This is a workaround for the fact that, as mentioned above, `Subscription` is a struct when I would have liked it to be a protocol. It allows people mocking our SDK to create a `Subscription` so that they can return it from their mocks. The intention of this initializer is that if you use it, then the created `Subscription` will just replay the sequence that you pass it. It is a programmer error to pass a throwing AsyncSequence.
-    public init<T: AsyncSequence & Sendable>(mockAsyncSequence: T) where T.Element == Element {
+    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying) where Underlying.Element == Element {
         mode = .mockAsyncSequence(.init(asyncSequence: mockAsyncSequence))
     }
 

--- a/Tests/AblyChatTests/Helpers/SynchronizedAccess.swift
+++ b/Tests/AblyChatTests/Helpers/SynchronizedAccess.swift
@@ -4,8 +4,8 @@ import Foundation
 ///
 /// Don’t overestimate the abilities of this property wrapper; it won’t allow you to, for example, increment a counter in a threadsafe manner.
 @propertyWrapper
-struct SynchronizedAccess<T> {
-    var wrappedValue: T {
+struct SynchronizedAccess<Value> {
+    var wrappedValue: Value {
         get {
             mutex.withLock {
                 _wrappedValue
@@ -19,10 +19,10 @@ struct SynchronizedAccess<T> {
         }
     }
 
-    private var _wrappedValue: T
+    private var _wrappedValue: Value
     private var mutex = NSLock()
 
-    init(wrappedValue: T) {
+    init(wrappedValue: Value) {
         _wrappedValue = wrappedValue
     }
 }

--- a/Tests/AblyChatTests/MessageSubscriptionTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionTests.swift
@@ -2,22 +2,22 @@
 import AsyncAlgorithms
 import Testing
 
-private final class MockPaginatedResult<T: Equatable>: PaginatedResult {
-    var items: [T] { fatalError("Not implemented") }
+private final class MockPaginatedResult<Item: Equatable>: PaginatedResult {
+    var items: [Item] { fatalError("Not implemented") }
 
     var hasNext: Bool { fatalError("Not implemented") }
 
     var isLast: Bool { fatalError("Not implemented") }
 
-    var next: (any AblyChat.PaginatedResult<T>)? { fatalError("Not implemented") }
+    var next: (any AblyChat.PaginatedResult<Item>)? { fatalError("Not implemented") }
 
-    var first: any AblyChat.PaginatedResult<T> { fatalError("Not implemented") }
+    var first: any AblyChat.PaginatedResult<Item> { fatalError("Not implemented") }
 
-    var current: any AblyChat.PaginatedResult<T> { fatalError("Not implemented") }
+    var current: any AblyChat.PaginatedResult<Item> { fatalError("Not implemented") }
 
     init() {}
 
-    static func == (lhs: MockPaginatedResult<T>, rhs: MockPaginatedResult<T>) -> Bool {
+    static func == (lhs: MockPaginatedResult<Item>, rhs: MockPaginatedResult<Item>) -> Bool {
         lhs.items == rhs.items &&
             lhs.hasNext == rhs.hasNext &&
             lhs.isLast == rhs.isLast


### PR DESCRIPTION
Swift encourages the use of descriptive names instead of single letters. [From the Swift book](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics/):

> In most cases, type parameters have descriptive names, such as Key and Value in Dictionary<Key, Value> and Element in Array<Element>, which tells the reader about the relationship between the type parameter and the generic type or function it’s used in. However, when there isn’t a meaningful relationship between them, it’s traditional to name them using single letters such as T, U, and V, such as T in the swapTwoValues(_:_:) function above.

So I've used my judgement here a bit and renamed some things and left some as single letters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated generic parameter names throughout the codebase for improved clarity and consistency. No changes to functionality or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->