### PR TITLE
[ECO-5000] Keep our duplicate of `ARTRealtimePresenceQuery`

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -309,7 +309,7 @@ class MockPresence: Presence {
         }
     }
 
-    func get(params _: PresenceQuery) async throws(ARTErrorInfo) -> [PresenceMember] {
+    func get(params _: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
         MockStrings.names.shuffled().map { name in
             PresenceMember(
                 clientID: name,

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -17,7 +17,7 @@ internal final class DefaultPresence: Presence, EmitsDiscontinuities {
         try await implementation.get()
     }
 
-    internal func get(params: PresenceQuery) async throws(ARTErrorInfo) -> [PresenceMember] {
+    internal func get(params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
         try await implementation.get(params: params)
     }
 
@@ -102,7 +102,7 @@ internal final class DefaultPresence: Presence, EmitsDiscontinuities {
             }
         }
 
-        internal func get(params: PresenceQuery) async throws(ARTErrorInfo) -> [PresenceMember] {
+        internal func get(params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
             do throws(InternalError) {
                 logger.log(message: "Getting presence with params: \(params)", level: .debug)
 

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -281,7 +281,7 @@ public struct PresenceQuery: Sendable {
     public var connectionID: String?
     public var waitForSync = true
 
-    internal init(limit: Int = 100, clientID: String? = nil, connectionID: String? = nil, waitForSync: Bool = true) {
+    public init(limit: Int = 100, clientID: String? = nil, connectionID: String? = nil, waitForSync: Bool = true) {
         self.limit = limit
         self.clientID = clientID
         self.connectionID = connectionID

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -276,13 +276,11 @@ public struct PresenceEvent: Sendable {
 //
 // So, for now, let’s just accept this copy (which I don’t think is a big problem anyway); we can always revisit it with more Swift concurrency knowledge in the future. Created https://github.com/ably-labs/ably-chat-swift/issues/64 to revisit.
 public struct PresenceQuery: Sendable {
-    public var limit = 100
     public var clientID: String?
     public var connectionID: String?
     public var waitForSync = true
 
-    public init(limit: Int = 100, clientID: String? = nil, connectionID: String? = nil, waitForSync: Bool = true) {
-        self.limit = limit
+    public init(clientID: String? = nil, connectionID: String? = nil, waitForSync: Bool = true) {
         self.clientID = clientID
         self.connectionID = connectionID
         self.waitForSync = waitForSync
@@ -290,7 +288,6 @@ public struct PresenceQuery: Sendable {
 
     internal func asARTRealtimePresenceQuery() -> ARTRealtimePresenceQuery {
         let query = ARTRealtimePresenceQuery()
-        query.limit = UInt(limit)
         query.clientId = clientID
         query.connectionId = connectionID
         query.waitForSync = waitForSync

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -268,16 +268,15 @@ public struct PresenceEvent: Sendable {
     }
 }
 
-// This is a Sendable equivalent of ably-cocoa’s ARTRealtimePresenceQuery type.
-//
-// Originally, ``Presence/get(params:)`` accepted an ARTRealtimePresenceQuery object, but I’ve changed it to accept this type, because else when you try and write an actor that implements ``Presence``, you get a compiler error like "Non-sendable type 'ARTRealtimePresenceQuery' in parameter of the protocol requirement satisfied by actor-isolated instance method 'get(params:)' cannot cross actor boundary; this is an error in the Swift 6 language mode".
-//
-// Now, based on my limited understanding, you _should_ be able to send non-Sendable values from one isolation domain to another (the purpose of the "region-based isolation" and "`sending` parameters" features added in Swift 6), but to get this to work I had to mark ``Presence`` as requiring conformance to the `Actor` protocol, and since I didn’t understand _why_ I had to do that, I didn’t want to put it in the public API.
-//
-// So, for now, let’s just accept this copy (which I don’t think is a big problem anyway); we can always revisit it with more Swift concurrency knowledge in the future. Created https://github.com/ably-labs/ably-chat-swift/issues/64 to revisit.
+/// Describes the parameters accepted by ``Presence/get(params:)``.
 public struct PresenceParams: Sendable {
+    /// Filters the array of returned presence members by a specific client using its ID.
     public var clientID: String?
+
+    /// Filters the array of returned presence members by a specific connection using its ID.
     public var connectionID: String?
+
+    /// Sets whether to wait for a full presence set synchronization between Ably and the clients on the room to complete before returning the results. Synchronization begins as soon as the room is ``RoomStatus/attached``. When set to `true` the results will be returned as soon as the sync is complete. When set to `false` the current list of members will be returned without the sync completing. The default is `true`.
     public var waitForSync = true
 
     public init(clientID: String? = nil, connectionID: String? = nil, waitForSync: Bool = true) {

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -19,13 +19,13 @@ public protocol Presence: AnyObject, Sendable, EmitsDiscontinuities {
      * Method to get list of the current online users and returns the latest presence messages associated to it.
      *
      * - Parameters:
-     *   - params: ``PresenceQuery`` that control how the presence set is retrieved.
+     *   - params: ``PresenceParams`` that control how the presence set is retrieved.
      *
      * - Returns: An array of ``PresenceMember``s.
      *
      * - Throws: An `ARTErrorInfo`.
      */
-    func get(params: PresenceQuery) async throws(ARTErrorInfo) -> [PresenceMember]
+    func get(params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember]
 
     /**
      * Method to check if user with supplied clientId is online.
@@ -275,7 +275,7 @@ public struct PresenceEvent: Sendable {
 // Now, based on my limited understanding, you _should_ be able to send non-Sendable values from one isolation domain to another (the purpose of the "region-based isolation" and "`sending` parameters" features added in Swift 6), but to get this to work I had to mark ``Presence`` as requiring conformance to the `Actor` protocol, and since I didn’t understand _why_ I had to do that, I didn’t want to put it in the public API.
 //
 // So, for now, let’s just accept this copy (which I don’t think is a big problem anyway); we can always revisit it with more Swift concurrency knowledge in the future. Created https://github.com/ably-labs/ably-chat-swift/issues/64 to revisit.
-public struct PresenceQuery: Sendable {
+public struct PresenceParams: Sendable {
     public var clientID: String?
     public var connectionID: String?
     public var waitForSync = true


### PR DESCRIPTION
I originally created this as a way of getting around some compiler concurrency checking warnings when we used ably-cocoa's `ARTRealtimePresenceQuery` type. Now that we've switched to `@MainActor` in fc83fc1, we could switch back to using the ably-cocoa type.

However, I think it's best that we keep this Swift type, because I think it makes more sense to use a value type instead of the mutable reference type used by ably-cocoa, and it also means that we don't have to keep the incorrect `limit` property (see ably/ably-cocoa#2046).

Resolves #64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated presence query parameter type to a new format, focusing on filtering by client ID, connection ID, and sync options.
  - Removed support for setting a limit on presence queries.
  - Improved documentation for presence query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->