### PR TITLE
Drop Xcode 16.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Get started using the [📚 documentation](https://ably.com/docs/products/chat).
 
 ## Requirements
 
-Xcode 16 or later.
+Xcode 16.1 or later.
 
 ## Installation
 

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -134,7 +134,7 @@ struct GenerateMatrices: ParsableCommand {
     )
 
     mutating func run() throws {
-        let tooling = ["16.2", "16.3"].map { xcodeVersion in
+        let tooling = ["16.1", "16.2", "16.3"].map { xcodeVersion in
             [
                 "xcodeVersion": xcodeVersion,
             ]

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -134,14 +134,11 @@ struct GenerateMatrices: ParsableCommand {
     )
 
     mutating func run() throws {
-        let tooling = [
+        let tooling = ["16.2", "16.3"].map { xcodeVersion in
             [
-                "xcodeVersion": "16.2",
-            ],
-            [
-                "xcodeVersion": "16.3",
-            ],
-        ]
+                "xcodeVersion": xcodeVersion,
+            ]
+        }
 
         let matrix: [String: Any] = [
             "withoutPlatform": [


### PR DESCRIPTION
Turns out that fc83fc1 broke compilation in Xcode 16.0. I didn't notice this until now because I was using a later version locally and we were using a later version in CI.

The compilation error is happening in the tests, when using `#expect`. Not sure of what exactly triggers it, but it leads to errors like

> Sending main actor-isolated value of type '() -> [Comment]' with later accesses to nonisolated context risks causing data races

I didn't really understand the error message, and tried a few plausible things to fix it (mark closures as `@Sendable`, explicitly pass a closure for the `comment` autoclosure etc), to no avail.

So, I decided to give up and not sink more time into this. We're not at 1.0 yet, nor have we decided our policy on when we're allowed to increase our minimum supported Xcode version (for example on ably-cocoa we implicitly raise it frequently).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the minimum required Xcode version in the README to 16.1 or later.

- **Refactor**
  - Enhanced internal build tooling to support Xcode versions 16.1, 16.2, and 16.3. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->