### PR TITLE
[ECO-5241] Finish Ephemeral Typing

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -230,16 +230,17 @@ class MockTyping: Typing {
     let clientID: String
     let roomID: String
 
-    private let mockSubscriptions = MockSubscriptionStorage<TypingEvent>()
+    private let mockSubscriptions = MockSubscriptionStorage<TypingSetEvent>()
 
     init(clientID: String, roomID: String) {
         self.clientID = clientID
         self.roomID = roomID
     }
 
-    private func createSubscription() -> MockSubscription<TypingEvent> {
+    private func createSubscription() -> MockSubscription<TypingSetEvent> {
         mockSubscriptions.create(randomElement: {
-            TypingEvent(
+            TypingSetEvent(
+                type: .setChanged,
                 currentlyTyping: [
                     MockStrings.names.randomElement()!,
                     MockStrings.names.randomElement()!,
@@ -249,7 +250,7 @@ class MockTyping: Typing {
         }, interval: 2)
     }
 
-    func subscribe(bufferingPolicy _: BufferingPolicy) -> Subscription<TypingEvent> {
+    func subscribe(bufferingPolicy _: BufferingPolicy) -> Subscription<TypingSetEvent> {
         .init(mockAsyncSequence: createSubscription())
     }
 
@@ -258,11 +259,23 @@ class MockTyping: Typing {
     }
 
     func keystroke() async throws(ARTErrorInfo) {
-        mockSubscriptions.emit(TypingEvent(currentlyTyping: [clientID], change: .init(clientId: clientID, type: .started)))
+        mockSubscriptions.emit(
+            TypingSetEvent(
+                type: .setChanged,
+                currentlyTyping: [clientID],
+                change: .init(clientId: clientID, type: .started)
+            )
+        )
     }
 
     func stop() async throws(ARTErrorInfo) {
-        mockSubscriptions.emit(TypingEvent(currentlyTyping: [], change: .init(clientId: clientID, type: .stopped)))
+        mockSubscriptions.emit(
+            TypingSetEvent(
+                type: .setChanged,
+                currentlyTyping: [],
+                change: .init(clientId: clientID, type: .stopped)
+            )
+        )
     }
 }
 

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -43,7 +43,13 @@ internal enum OccupancyEvents: String {
     case meta = "[meta]occupancy"
 }
 
-public enum TypingEvents: String, Sendable {
+/// Enum representing the typing event types.
+public enum TypingEventType: String, Sendable {
     case started = "typing.started"
     case stopped = "typing.stopped"
+}
+
+/// Enum representing the typing set event types.
+public enum TypingSetEventType: String, Sendable {
+    case setChanged = "typing.set.changed"
 }

--- a/Sources/AblyChat/Typing.swift
+++ b/Sources/AblyChat/Typing.swift
@@ -16,12 +16,12 @@ public protocol Typing: AnyObject, Sendable {
      *
      * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``TypingEvent`` events.
      */
-    func subscribe(bufferingPolicy: BufferingPolicy) -> Subscription<TypingEvent>
+    func subscribe(bufferingPolicy: BufferingPolicy) -> Subscription<TypingSetEvent>
 
     /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
     ///
     /// The `Typing` protocol provides a default implementation of this method.
-    func subscribe() -> Subscription<TypingEvent>
+    func subscribe() -> Subscription<TypingSetEvent>
 
     /**
      * Get the current typers, a set of clientIds.
@@ -53,7 +53,7 @@ public protocol Typing: AnyObject, Sendable {
 }
 
 public extension Typing {
-    func subscribe() -> Subscription<TypingEvent> {
+    func subscribe() -> Subscription<TypingSetEvent> {
         subscribe(bufferingPolicy: .unbounded)
     }
 }
@@ -61,7 +61,9 @@ public extension Typing {
 /**
  * Represents a typing event.
  */
-public struct TypingEvent: Sendable {
+public struct TypingSetEvent: Sendable {
+    public var type: TypingSetEventType
+
     /**
      * Get a set of clientIds that are currently typing.
      */
@@ -72,16 +74,17 @@ public struct TypingEvent: Sendable {
       */
     public var change: Change
 
-    public init(currentlyTyping: Set<String>, change: Change) {
+    public init(type: TypingSetEventType, currentlyTyping: Set<String>, change: Change) {
+        self.type = type
         self.currentlyTyping = currentlyTyping
         self.change = change
     }
 
     public struct Change: Sendable {
         public var clientId: String
-        public var type: TypingEvents
+        public var type: TypingEventType
 
-        public init(clientId: String, type: TypingEvents) {
+        public init(clientId: String, type: TypingEventType) {
             self.clientId = clientId
             self.type = type
         }

--- a/Tests/AblyChatTests/DefaultTypingTests.swift
+++ b/Tests/AblyChatTests/DefaultTypingTests.swift
@@ -1,0 +1,293 @@
+import Ably
+@testable import AblyChat
+import Clocks
+import Foundation
+import Testing
+
+@MainActor
+struct DefaultTypingTests {
+    @available(iOS 16.0, tvOS 16.0, *)
+    private func createTyping(
+        channel: MockRealtimeChannel = MockRealtimeChannel(),
+        heartbeatThrottle: TimeInterval = 30, // Use a shorter throttle for faster tests
+        mockClock: MockTestClock = MockTestClock()
+    ) -> DefaultTyping {
+        let mockLogger = MockInternalLogger()
+
+        return DefaultTyping(
+            channel: channel,
+            roomID: "test-room",
+            clientID: "test-client",
+            logger: mockLogger,
+            heartbeatThrottle: heartbeatThrottle,
+            clock: mockClock
+        )
+    }
+
+    // @spec CHA-T4
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func keystroke_PublishesStartedEvent() async throws {
+        // Given
+        let channel = MockRealtimeChannel(initialState: .attached, attachBehavior: .complete(.success))
+        let typing = createTyping(channel: channel)
+
+        // When
+        try await typing.keystroke()
+
+        // Then
+        #expect(channel.publishedMessages.last?.name == TypingEventType.started.rawValue)
+        #expect(channel.publishedMessages.last?.extras?["ephemeral"] == .bool(true))
+    }
+
+    // @spec CHA-T4c
+    // @spec CHA-T14
+    // @spec CHA-T14a
+    // @spec CHA-T14b
+    // @spec CHA-T14b1
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func keystroke_multipleKeystroke_onlySends1WithinThrottleAllowance() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let mockClock = MockTestClock()
+        let typing = createTyping(channel: channel, mockClock: mockClock)
+
+        // When - send multiple keystrokes in quick succession
+        for _ in 0 ..< 5 {
+            Task {
+                try await typing.keystroke()
+            }
+        }
+
+        await mockClock.advance(by: 10)
+
+        // Then - only the first publish should happen
+        #expect(channel.publishedMessages.count == 1, "Only one message should be published during throttle period")
+    }
+
+    // @spec CHA-T6 - Tests subscribing to typing events
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func subscribe_ReturnsSubscriptionForTypingEvents() async {
+        // Given
+        let typing = createTyping()
+
+        // When
+        let subscription: Subscription<TypingSetEvent>? = typing.subscribe()
+
+        // Then
+        #expect(subscription != nil)
+    }
+
+    // @specOneOf(1/2) CHA-T6a - Tests subscription receives started event
+    // @specOneOf(1/2) CHA-T4a3 - Tests that publish has correct name and data
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func subscribe_ReceivesStartedTypingEvent() async throws {
+        // Given
+        let clientId = "test-client"
+        let typing = createTyping()
+
+        // When
+        let subscription = typing.subscribe()
+        subscription.emit(
+            TypingSetEvent(
+                type: .setChanged,
+                currentlyTyping: [clientId],
+                change: .init(clientId: clientId, type: .started)
+            )
+        )
+
+        // Then
+        let typingEvent = try #require(await subscription.first { @Sendable _ in true })
+        #expect(typingEvent.change.type == .started)
+        #expect(typingEvent.change.clientId == clientId)
+        #expect(typingEvent.currentlyTyping == [clientId])
+    }
+
+    // @specOneOf(2/2) CHA-T6a - Tests subscription receives stopped event
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func subscribe_ReceivesStoppedTypingEvent() async throws {
+        // Given
+        let clientId = "test-client"
+        let typing = createTyping()
+
+        // When
+        let subscription = typing.subscribe()
+        subscription.emit(
+            TypingSetEvent(
+                type: .setChanged,
+                currentlyTyping: [],
+                change: .init(clientId: clientId, type: .stopped)
+            )
+        )
+
+        // Then
+        let typingEvent = try #require(await subscription.first { @Sendable _ in true })
+        #expect(typingEvent.change.type == .stopped)
+        #expect(typingEvent.change.clientId == clientId)
+        #expect(typingEvent.currentlyTyping.isEmpty)
+    }
+
+    // @spec CHA-T9 - Tests retrieving currently typing clients
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func get_ReturnsCurrentlyTypingClients() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let mockClock = MockTestClock()
+        let typing = createTyping(channel: channel, mockClock: mockClock)
+
+        // Setup subscription and receive a typing event
+        _ = typing.subscribe()
+
+        let message = ARTMessage(name: TypingEventType.started.rawValue, data: [], clientId: "test-client")
+        channel.simulateIncomingMessage(message, for: TypingEventType.started.rawValue)
+
+        // When
+        let typingClients = try await typing.get()
+
+        // Then
+        #expect(typingClients.contains("test-client"))
+    }
+
+    // @specOneOf(2/2) CHA-T4a3 - Tests that publish has ephemeral flag
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func keystroke_PublishesWithEphemeralFlag() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let typing = createTyping(channel: channel)
+
+        // When
+        try await typing.keystroke()
+
+        // Then
+        let message = channel.publishedMessages.last
+        #expect(message?.extras?["ephemeral"] == .bool(true))
+    }
+
+    // @specOneOf(3/3) CHA-T4a4 - Tests that heartbeat timer is set after successful publish
+    // @spec CHA-T4c1 - Tests that keystroke doesn't send event if already typing
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func keystroke_SetsHeartbeatTimer() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let mockClock = MockTestClock()
+        let typing = createTyping(channel: channel, mockClock: mockClock)
+
+        // When
+        try await typing.keystroke()
+
+        // Then - Make a second keystroke attempt that should be throttled
+        let publishCount = channel.publishedMessages.count
+        try await typing.keystroke()
+        #expect(channel.publishedMessages.count == publishCount, "Heartbeat timer should throttle second publish")
+    }
+
+    // @spec CHA-T5 - Tests stop method
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func stop_PublishesStoppedEvent() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let typing = createTyping(channel: channel)
+
+        // Start typing first
+        try await typing.keystroke()
+
+        // When
+        try await typing.stop()
+
+        // Then
+        #expect(channel.publishedMessages.last?.name == TypingEventType.stopped.rawValue)
+    }
+
+    // @spec CHA-T5a - Tests stop is no-op if not typing
+    // @spec CHA-T13b5 - Tests that stop events for non-typing clients are ignored
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func stop_IsNoOpWhenNotTyping() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let typing = createTyping(channel: channel)
+
+        // When - Stop without starting
+        try await typing.stop()
+
+        // Then
+        #expect(channel.publishedMessages.isEmpty)
+    }
+
+    // @spec CHA-T5d - Tests publish for stop has correct format
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func stop_PublishesCorrectFormatMessage() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let typing = createTyping(channel: channel)
+
+        // Start typing first
+        try await typing.keystroke()
+
+        // When
+        try await typing.stop()
+
+        // Then
+        let message = channel.publishedMessages.last
+        #expect(message?.name == TypingEventType.stopped.rawValue)
+        #expect(message?.data == nil)
+        #expect(message?.extras?["ephemeral"] == .bool(true))
+    }
+
+    // @spec CHA-T5e - Tests stop unsets heartbeat timer
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func stop_UnsetsHeartbeatTimer() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let typing = createTyping(channel: channel)
+
+        // Start typing
+        try await typing.keystroke()
+
+        // When
+        try await typing.stop()
+
+        // Then - Another keystroke should publish (if timer was cancelled)
+        try await typing.keystroke()
+        #expect(channel.publishedMessages.count == 3)
+        #expect(channel.publishedMessages.last?.name == TypingEventType.started.rawValue)
+    }
+
+    // @specOneOf(3/3) CHA-T13b1 - Tests timeout setup for typing clients
+    // @spec CHA-T13b3 - Tests that timeout expiration removes client from typing set
+    @Test
+    @available(iOS 16.0, tvOS 16.0, *)
+    func typing_ExpiresAfterHeartbeatThrottle() async throws {
+        // Given
+        let channel = MockRealtimeChannel()
+        let mockClock = MockTestClock()
+        let heartbeatThrottle: TimeInterval = 5
+        let typing = createTyping(channel: channel, heartbeatThrottle: heartbeatThrottle, mockClock: mockClock)
+        let subscription = typing.subscribe()
+
+        // Simulate someone started typing
+        let message = ARTMessage(name: TypingEventType.started.rawValue, data: [], clientId: "test-client")
+        channel.simulateIncomingMessage(message, for: TypingEventType.started.rawValue)
+
+        // When - advance clock past heartbeat + grace period
+        await mockClock.advance(by: heartbeatThrottle + 2)
+
+        // Then - should receive stopped event due to timeout
+        async let stoppedEvent = await subscription.first { event in
+            event.change.type == .stopped && event.change.clientId == "test-client"
+        }
+
+        await #expect(stoppedEvent != nil)
+        #expect(try await typing.get().isEmpty)
+    }
+}

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -338,7 +338,7 @@ struct IntegrationTests {
         try await txRoom.typing.keystroke()
 
         // (3) Wait for the typing event to be received
-        var typingEvents: [TypingEvent] = []
+        var typingEvents: [TypingSetEvent] = []
         for await typingEvent in rxTypingSubscription {
             typingEvents.append(typingEvent)
             if typingEvents.count == 1 { break }

--- a/Tests/AblyChatTests/TypingTimerManagerTests.swift
+++ b/Tests/AblyChatTests/TypingTimerManagerTests.swift
@@ -1,0 +1,168 @@
+@testable import AblyChat
+import Clocks
+import Foundation
+import Testing
+
+@MainActor
+final class TypingTimerManagerTests {
+    var mockLogger: MockInternalLogger!
+
+    @available(iOS 16.0, tvOS 16, *)
+    func createTypingTimerManager(with testClock: MockTestClock) -> TypingTimerManager<MockTestClock> {
+        mockLogger = MockInternalLogger()
+        return TypingTimerManager(
+            heartbeatThrottle: 1.0,
+            gracePeriod: 0.5,
+            logger: mockLogger,
+            clock: testClock
+        )
+    }
+
+    // @specOneOf(1/3) CHA-T4a4 - Tests the heartbeat timer initialization and state management
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testHeartbeatTimerLifecycle() async {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+        #expect(!timerManager.isHeartbeatTimerActive)
+
+        timerManager.startHeartbeatTimer()
+        #expect(timerManager.isHeartbeatTimerActive)
+
+        timerManager.cancelHeartbeatTimer()
+        #expect(!timerManager.isHeartbeatTimerActive)
+    }
+
+    // @specOneOf(2/3) CHA-T4a4 - Tests heartbeat timer expiration behavior
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testHeartbeatTimerExpiration() async {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+
+        timerManager.startHeartbeatTimer()
+        #expect(timerManager.isHeartbeatTimerActive)
+
+        await mockClock.advance(by: 1.1)
+        #expect(!timerManager.isHeartbeatTimerActive)
+    }
+
+    // @specOneOf(1/3) CHA-T13b1 - Tests starting "is somebody typing" timers to add client to typing set
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testStartTypingTimer() {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+
+        #expect(!timerManager.isCurrentlyTyping(clientID: "client1"))
+
+        timerManager.startTypingTimer(for: "client1")
+        #expect(timerManager.isCurrentlyTyping(clientID: "client1"))
+        #expect(timerManager.currentlyTypingClientIDs() == ["client1"])
+    }
+
+    // @specOneOf(2/3) CHA-T13b1 - Tests the currentlyTypingClients method returns correct set of typing clients.
+    // @spec CHA-T13b4 - Tests canceling typing timer to remove client from typing set
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testMultipleClientTyping() {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+
+        timerManager.startTypingTimer(for: "client1")
+        timerManager.startTypingTimer(for: "client2")
+        timerManager.startTypingTimer(for: "client3")
+
+        #expect(timerManager.currentlyTypingClientIDs() == ["client1", "client2", "client3"])
+
+        timerManager.cancelTypingTimer(for: "client2")
+
+        #expect(timerManager.currentlyTypingClientIDs() == ["client1", "client3"])
+    }
+
+    // @spec CHA-T13b3 - Tests timeout expiration removing client from typing set and calling the onCancelled handler.
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testTypingTimerExpiration() async {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+
+        var handlerCalled = false
+
+        timerManager.startTypingTimer(for: "client1") {
+            handlerCalled = true
+        }
+
+        #expect(timerManager.isCurrentlyTyping(clientID: "client1"))
+
+        // Advance time to trigger timer expiration (heartbeatThrottle + gracePeriod)
+        await mockClock.advance(by: 1.6)
+
+        #expect(handlerCalled)
+        #expect(!timerManager.isCurrentlyTyping(clientID: "client1"))
+        #expect(timerManager.currentlyTypingClientIDs().isEmpty)
+    }
+
+    // @spec CHA-T13b2 - Tests that each additional typing heartbeat resets the timeout
+    // @spec CHA-T4b - Tests extending the timeout when typing is already in progress
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testTimerReset() async {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+
+        var handlerCalled = false
+
+        timerManager.startTypingTimer(for: "client1") {
+            handlerCalled = true
+        }
+
+        // Advance time but not enough to expire
+        await mockClock.advance(by: 1.0)
+
+        // Reset timer before it expires
+        timerManager.startTypingTimer(for: "client1") {
+            handlerCalled = true
+        }
+
+        // Advance time enough to expire original timer
+        await mockClock.advance(by: 0.7)
+
+        // Client should still be typing because we reset the timer
+        #expect(timerManager.isCurrentlyTyping(clientID: "client1"))
+        #expect(!handlerCalled)
+
+        // Now advance enough to expire the reset timer
+        await mockClock.advance(by: 2.0)
+
+        #expect(handlerCalled)
+        #expect(!timerManager.isCurrentlyTyping(clientID: "client1"))
+    }
+
+    // @spec CHA-T10 - Users can configure the heartbeat interval (set to 1 in createTypingTimerManager)
+    // @spec CHA-T10a1 - Tests that grace period is correctly applied to prevent flickering
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func testGracePeriodTiming() async {
+        let mockClock = MockTestClock()
+        let timerManager = createTypingTimerManager(with: mockClock)
+
+        var handlerCalled = false
+
+        timerManager.startTypingTimer(for: "client1") {
+            handlerCalled = true
+        }
+
+        // Advance by heartbeatThrottle only - should still be typing
+        await mockClock.advance(by: 1.0)
+
+        #expect(timerManager.isCurrentlyTyping(clientID: "client1"))
+        #expect(!handlerCalled)
+
+        // Advance by grace period - now should expire
+        await mockClock.advance(by: 0.5)
+
+        #expect(handlerCalled)
+        #expect(!timerManager.isCurrentlyTyping(clientID: "client1"))
+    }
+}


### PR DESCRIPTION
- Adds a new TypingSetEventType enum as a root property within the TypingSetEvent (formerly TypingEvent)
- Reintroduces typing tests