### PR TITLE
[ECO-5324] Message reactions

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b9346f189c75374e2fc2168582afbb7b92520630f6c61c0fc714c7cc0ea60199",
+  "originHash" : "1ceb92e31c2ae82acbe1b60072e8a24852977282d2ec582907a80f43b395de8e",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "c5347707e4f9fb907df0e5c334de445899a79783",
-        "version" : "1.2.40"
+        "revision" : "05c9a9529c67a9a1d82e4f51d359df9e0a20b299",
+        "version" : "1.2.41"
       }
     },
     {

--- a/Example/AblyChatExample/MessageViews/BlurView.swift
+++ b/Example/AblyChatExample/MessageViews/BlurView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+// UIKit blur view for SwiftUI
+#if os(iOS)
+    struct BlurView: UIViewRepresentable {
+        let style: UIBlurEffect.Style
+        func makeUIView(context _: Context) -> UIVisualEffectView {
+            UIVisualEffectView(effect: UIBlurEffect(style: style))
+        }
+
+        func updateUIView(_: UIVisualEffectView, context _: Context) {}
+    }
+
+#elseif os(macOS)
+    struct BlurView: NSViewRepresentable {
+        let material: NSVisualEffectView.Material
+        let blendingMode: NSVisualEffectView.BlendingMode
+
+        func makeNSView(context _: Context) -> NSVisualEffectView {
+            let view = NSVisualEffectView()
+            view.material = material
+            view.blendingMode = blendingMode
+            view.state = .active
+            return view
+        }
+
+        func updateNSView(_: NSVisualEffectView, context _: Context) {}
+    }
+#endif

--- a/Example/AblyChatExample/MessageViews/MessageReactionSummaryView.swift
+++ b/Example/AblyChatExample/MessageViews/MessageReactionSummaryView.swift
@@ -1,0 +1,83 @@
+import AblyChat
+import SwiftUI
+
+struct MessageReactionSummaryView: View {
+    let summary: MessageReactionSummary
+    let currentClientID: String
+
+    let onPickReaction: () -> Void
+    let onAddReaction: (String) -> Void
+    let onDeleteReaction: (String) -> Void
+
+    @State private var selectedEmoji: String?
+    @State private var showReactionMenu = false
+    @State private var showAllReactionsSheet = false
+
+    private let maxReactionsCount = 5
+
+    var reactions: [String: MessageReactionSummary.ClientIdList] {
+        summary.distinct
+    }
+
+    var body: some View {
+        HStack {
+            let reactions = reactions
+            if !reactions.isEmpty {
+                Button(action: onPickReaction) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 14, weight: .bold))
+                        .frame(width: 24, height: 24)
+                        .background(Circle().fill(Color.gray.opacity(0.2)))
+                }
+                .buttonStyle(.plain)
+            }
+            ForEach(reactions.keys.sorted().prefix(maxReactionsCount), id: \.self) { emoji in
+                if let item = reactions[emoji] {
+                    Text("\(emoji) \(item.total)")
+                        .frame(minWidth: 40, minHeight: 24)
+                        .font(.system(size: 12, weight: .regular))
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(12)
+                        .padding(left: -2)
+                        .onTapGesture {
+                            selectedEmoji = emoji
+                            showReactionMenu = true
+                        }
+                }
+            }
+            if !reactions.isEmpty {
+                Button("•••") {
+                    showAllReactionsSheet = true
+                }
+                .padding(left: 2)
+                .lineLimit(1)
+                .buttonStyle(.plain)
+            }
+            Spacer()
+        }
+        .confirmationDialog(
+            "Reaction Options",
+            isPresented: $showReactionMenu,
+            titleVisibility: .visible
+        ) {
+            Button("Show who reacted") {
+                showAllReactionsSheet = true
+            }
+            if let emoji = selectedEmoji {
+                if reactions[emoji]?.clientIds.contains(currentClientID) ?? false {
+                    Button("Remove my \(emoji)", role: .destructive) {
+                        onDeleteReaction(emoji)
+                    }
+                } else {
+                    Button("React with \(emoji)") {
+                        onAddReaction(emoji)
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .sheet(isPresented: $showAllReactionsSheet) {
+            MessageReactionsSheet(uniqueOrDistinct: reactions)
+        }
+    }
+}

--- a/Example/AblyChatExample/MessageViews/MessageReactionsPicker.swift
+++ b/Example/AblyChatExample/MessageViews/MessageReactionsPicker.swift
@@ -1,0 +1,72 @@
+import AblyChat
+import SwiftUI
+
+struct MessageReactionsPicker: View {
+    let onReactionSelected: (String) -> Void
+    private let emojies = Emoji.all()
+
+    @Environment(\.dismiss)
+    private var dismiss
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                // Drag indicator
+                Capsule()
+                    .frame(width: 40, height: 6)
+                    .foregroundColor(Color.secondary.opacity(0.3))
+                    .padding(.top, 10)
+                    .padding(.bottom, 16)
+
+                Text("Emoji Picker")
+                    .font(.headline)
+                    .padding(.bottom, 12)
+
+                ScrollView {
+                    let columns = [
+                        GridItem(.adaptive(minimum: 60, maximum: 120), spacing: 5),
+                    ]
+                    LazyVGrid(columns: columns, spacing: 5) {
+                        ForEach(emojies, id: \.self) { emoji in
+                            VStack(spacing: 4) {
+                                Text(emoji)
+                                    .font(.system(size: 32))
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 12)
+                            .onTapGesture {
+                                onReactionSelected(emoji)
+                                dismiss()
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                }
+                Button("Dismiss", role: .cancel) {
+                    dismiss()
+                }
+                .font(.title3)
+                .padding(24)
+            }
+            .frame(maxWidth: .infinity)
+            #if os(iOS)
+                .background(
+                    BlurView(style: .systemUltraThinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                )
+            #elseif os(macOS)
+                .background(
+                    BlurView(material: .hudWindow, blendingMode: .withinWindow)
+                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                )
+            #endif
+                .padding(.horizontal, 0)
+                .padding(.bottom, 0)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .presentationBackground(.clear)
+        .presentationDetents([.fraction(0.5)])
+        .padding(10)
+        .transition(.move(edge: .bottom))
+    }
+}

--- a/Example/AblyChatExample/MessageViews/MessageReactionsSheet.swift
+++ b/Example/AblyChatExample/MessageViews/MessageReactionsSheet.swift
@@ -1,0 +1,119 @@
+import AblyChat
+import SwiftUI
+
+struct MessageReactionsSheet: View {
+    struct ReactionItem: Identifiable, Equatable {
+        let emoji: String
+        let author: String
+        var count: Int = 1
+
+        var id: String {
+            "\(author)-\(emoji)"
+        }
+    }
+
+    private var reactions: [String: ReactionItem] = [:]
+
+    @Environment(\.dismiss)
+    private var dismiss
+
+    init(uniqueOrDistinct: [String: MessageReactionSummary.ClientIdList]) {
+        for (emoji, clientList) in uniqueOrDistinct {
+            for clientId in clientList.clientIds {
+                let key = "\(clientId)-\(emoji)"
+                reactions[key] = ReactionItem(
+                    emoji: emoji,
+                    author: clientId,
+                    count: 1
+                )
+            }
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                // Drag indicator
+                Capsule()
+                    .frame(width: 40, height: 6)
+                    .foregroundColor(Color.secondary.opacity(0.3))
+                    .padding(.top, 10)
+                    .padding(.bottom, 16)
+
+                Text("All Reactions")
+                    .font(.headline)
+                    .padding(.bottom, 12)
+
+                ScrollView {
+                    let columns = [
+                        GridItem(.adaptive(minimum: 60, maximum: 120), spacing: 5),
+                    ]
+                    LazyVGrid(columns: columns, spacing: 5) {
+                        ForEach(reactions.values.sorted { r1, r2 in
+                            if r1.author == r2.author {
+                                r1.emoji < r2.emoji
+                            } else {
+                                r1.author < r2.author
+                            }
+                        }, id: \.id) { item in
+                            VStack(spacing: 4) {
+                                Text(item.emoji)
+                                    .font(.system(size: 24))
+                                if item.count > 1 {
+                                    Text("\(item.author) (\(item.count))")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                } else {
+                                    Text(item.author)
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                }
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 12)
+                            #if os(iOS)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 16)
+                                        .fill(Color(.systemBackground).opacity(0.7))
+                                )
+                            #elseif os(macOS)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 16)
+                                        .fill(Color(NSColor.windowBackgroundColor).opacity(0.7))
+                                )
+                            #endif
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+
+                Button("Dismiss", role: .cancel) {
+                    dismiss()
+                }
+                .font(.title3)
+                .padding(24)
+            }
+            .frame(maxWidth: .infinity)
+            #if os(iOS)
+                .background(
+                    BlurView(style: .systemUltraThinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                )
+            #elseif os(macOS)
+                .background(
+                    BlurView(material: .hudWindow, blendingMode: .withinWindow)
+                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                )
+            #endif
+                .padding(.horizontal, 0)
+                .padding(.bottom, 0)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .presentationBackground(.clear)
+        .transition(.move(edge: .bottom))
+    }
+}

--- a/Example/AblyChatExample/Misc/Utils.swift
+++ b/Example/AblyChatExample/Misc/Utils.swift
@@ -1,5 +1,6 @@
 import Ably
 import AblyChat
+import SwiftUI
 
 /// Executes closure on the `MainActor` after a delay (in seconds).
 func after(_ delay: TimeInterval, closure: @MainActor @escaping () -> Void) {
@@ -10,13 +11,43 @@ func after(_ delay: TimeInterval, closure: @MainActor @escaping () -> Void) {
 }
 
 /// Periodically executes closure on the `MainActor`with interval (in seconds).
-func periodic(with interval: TimeInterval, closure: @MainActor @escaping () -> Bool) {
+func periodic(with interval: @escaping @MainActor @Sendable () -> Double, closure: @escaping @MainActor () -> Bool) {
     Task {
         while true {
-            try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            try? await Task.sleep(nanoseconds: UInt64(interval() * 1_000_000_000))
             if await !closure() {
                 break
             }
         }
+    }
+}
+
+@MainActor
+func byChance(_ probability: Double) -> Bool {
+    var chance = probability
+    if chance <= 1 {
+        chance = probability * 100
+    }
+    if [Int](1 ... 100).randomElement()! <= Int(chance) {
+        return true
+    }
+    return false
+}
+
+extension View {
+    func padding(left: CGFloat) -> some View {
+        padding(.leading, left)
+    }
+
+    func padding(right: CGFloat) -> some View {
+        padding(.trailing, right)
+    }
+
+    func padding(top: CGFloat) -> some View {
+        padding(.top, top)
+    }
+
+    func padding(bottom: CGFloat) -> some View {
+        padding(.bottom, bottom)
     }
 }

--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -95,3 +95,22 @@ extension Reaction {
         type
     }
 }
+
+enum Emoji {
+    static func random() -> String {
+        let emojiRange = 0x1F600 ... 0x1F64F // All Emoticons
+//        let emojiRange = 0x1F600...0x1F607 // Smiles
+        let randomScalar = UnicodeScalar(Int.random(in: emojiRange))!
+        return String(randomScalar)
+    }
+
+    static func all() -> [String] {
+        let emojiRange = 0x1F600 ... 0x1F64F // All emoticons
+        return emojiRange.map { String(UnicodeScalar($0)!) }
+    }
+
+    static func smiles() -> [String] {
+        let emojiRange = 0x1F600 ... 0x1F607 // Smiles
+        return emojiRange.map { String(UnicodeScalar($0)!) }
+    }
+}

--- a/Example/AblyChatExample/Mocks/MockRealtime.swift
+++ b/Example/AblyChatExample/Mocks/MockRealtime.swift
@@ -101,11 +101,12 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, Sendable {
     }
 
     final class Channel: RealtimeChannelProtocol {
+        let presence = RealtimePresence()
+        let annotations = RealtimeAnnotations()
+
         var state: ARTRealtimeChannelState {
             fatalError("Not implemented")
         }
-
-        let presence = RealtimePresence()
 
         var errorReason: ARTErrorInfo? {
             fatalError("Not implemented")
@@ -340,6 +341,28 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, Sendable {
         func history(_: @escaping ARTPaginatedPresenceCallback) {}
 
         func history(_: ARTRealtimeHistoryQuery?, callback _: @escaping ARTPaginatedPresenceCallback) throws {
+            fatalError("Not implemented")
+        }
+    }
+
+    final class RealtimeAnnotations: RealtimeAnnotationsProtocol {
+        func subscribe(_: @escaping ARTAnnotationCallback) -> ARTEventListener? {
+            fatalError("Not implemented")
+        }
+
+        func subscribe(_: String, callback _: @escaping ARTAnnotationCallback) -> ARTEventListener? {
+            fatalError("Not implemented")
+        }
+
+        func unsubscribe() {
+            fatalError("Not implemented")
+        }
+
+        func unsubscribe(_: ARTEventListener) {
+            fatalError("Not implemented")
+        }
+
+        func unsubscribe(_: String, listener _: ARTEventListener) {
             fatalError("Not implemented")
         }
     }

--- a/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
@@ -9,13 +9,20 @@ class MockSubscriptionStorage<Element: Sendable> {
         let subscription: Subscription
         let callback: (Element) -> Void
 
-        init(randomElement: @escaping @Sendable () -> Element, interval: Double, callback: @escaping @MainActor (Element) -> Void, onTerminate: @escaping () -> Void) {
+        init(
+            randomElement: @escaping @MainActor @Sendable () -> Element?,
+            interval: @escaping @MainActor @Sendable () -> Double,
+            callback: @escaping @MainActor (Element) -> Void,
+            onTerminate: @escaping @MainActor () -> Void
+        ) {
             self.callback = callback
 
             var needNext = true
             periodic(with: interval) {
                 if needNext {
-                    callback(randomElement())
+                    if let randomElement = randomElement() {
+                        callback(randomElement)
+                    }
                 }
                 return needNext
             }
@@ -29,8 +36,8 @@ class MockSubscriptionStorage<Element: Sendable> {
     private var subscriptions: [UUID: SubscriptionItem] = [:]
 
     func create(
-        randomElement: @escaping @Sendable () -> Element,
-        interval: Double,
+        randomElement: @escaping @MainActor @Sendable () -> Element?,
+        interval: @autoclosure @escaping @MainActor @Sendable () -> Double,
         callback: @escaping @MainActor (Element) -> Void
     ) -> SubscriptionProtocol {
         let id = UUID()
@@ -60,13 +67,20 @@ class MockStatusSubscriptionStorage<Element: Sendable> {
         let subscription: StatusSubscription
         let callback: (Element) -> Void
 
-        init(randomElement: @escaping @Sendable () -> Element, interval: Double, callback: @escaping @MainActor (Element) -> Void, onTerminate: @escaping () -> Void) {
+        init(
+            randomElement: @escaping @MainActor @Sendable () -> Element?,
+            interval: @escaping @MainActor @Sendable () -> Double,
+            callback: @escaping @MainActor (Element) -> Void,
+            onTerminate: @escaping @MainActor () -> Void
+        ) {
             self.callback = callback
 
             var needNext = true
             periodic(with: interval) {
                 if needNext {
-                    callback(randomElement())
+                    if let randomElement = randomElement() {
+                        callback(randomElement)
+                    }
                 }
                 return needNext
             }
@@ -80,8 +94,8 @@ class MockStatusSubscriptionStorage<Element: Sendable> {
     private var subscriptions: [UUID: SubscriptionItem] = [:]
 
     func create(
-        randomElement: @escaping @Sendable () -> Element,
-        interval: Double,
+        randomElement: @escaping @MainActor @Sendable () -> Element?,
+        interval: @autoclosure @escaping @MainActor @Sendable () -> Double,
         callback: @escaping @MainActor (Element) -> Void
     ) -> StatusSubscriptionProtocol {
         let id = UUID()
@@ -112,9 +126,9 @@ class MockMessageSubscriptionStorage<Element: Sendable> {
         let callback: (Element) -> Void
 
         init(
-            randomElement: @escaping @Sendable () -> Element,
-            previousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>,
-            interval: Double,
+            randomElement: @escaping @MainActor @Sendable () -> Element,
+            previousMessages: @escaping @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>,
+            interval: @escaping @MainActor @Sendable () -> Double,
             callback: @escaping @MainActor (Element) -> Void,
             onTerminate: @escaping () -> Void
         ) {
@@ -137,9 +151,9 @@ class MockMessageSubscriptionStorage<Element: Sendable> {
     private var subscriptions: [UUID: SubscriptionItem] = [:]
 
     func create(
-        randomElement: @escaping @Sendable () -> Element,
-        previousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>,
-        interval: Double,
+        randomElement: @escaping @MainActor @Sendable () -> Element,
+        previousMessages: @escaping @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>,
+        interval: @autoclosure @escaping @MainActor @Sendable () -> Double,
         callback: @escaping @MainActor (Element) -> Void
     ) -> MessageSubscriptionResponseProtocol {
         let id = UUID()

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0ccbd47165703b8768f74befcbda850f9e56250ff5da39cc52078b9c3cab7df9",
+  "originHash" : "130760bd033e28534695304b0dca1a7a183f37145284f7399dec4c704726635d",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "c5347707e4f9fb907df0e5c334de445899a79783",
-        "version" : "1.2.40"
+        "revision" : "05c9a9529c67a9a1d82e4f51d359df9e0a20b299",
+        "version" : "1.2.41"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.40"
+            from: "1.2.41"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
@@ -13,4 +13,7 @@ extension ARTWrapperSDKProxyRealtimeChannel: RealtimeChannelProtocol {}
 extension ARTRealtimePresence: RealtimePresenceProtocol {}
 extension ARTWrapperSDKProxyRealtimePresence: RealtimePresenceProtocol {}
 
+extension ARTRealtimeAnnotations: RealtimeAnnotationsProtocol {}
+extension ARTWrapperSDKProxyRealtimeAnnotations: RealtimeAnnotationsProtocol {}
+
 extension ARTConnection: ConnectionProtocol {}

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -10,8 +10,8 @@ internal final class ChatAPI: Sendable {
     }
 
     // (CHA-M6) Messages should be queryable from a paginated REST API.
-    internal func getMessages(roomId: String, params: QueryOptions) async throws(InternalError) -> any PaginatedResult<Message> {
-        let endpoint = "\(apiVersionV3)/rooms/\(roomId)/messages"
+    internal func getMessages(roomID: String, params: QueryOptions) async throws(InternalError) -> any PaginatedResult<Message> {
+        let endpoint = "\(apiVersionV3)/rooms/\(roomID)/messages"
         let result: Result<PaginatedResultWrapper<Message>, InternalError> = await makePaginatedRequest(endpoint, params: params.asQueryItems())
         return try result.get()
     }
@@ -41,12 +41,12 @@ internal final class ChatAPI: Sendable {
 
     // (CHA-M3) Messages are sent to Ably via the Chat REST API, using the send method.
     // (CHA-M3a) When a message is sent successfully, the caller shall receive a struct representing the Message in response (as if it were received via Realtime event).
-    internal func sendMessage(roomId: String, params: SendMessageParams) async throws(InternalError) -> Message {
+    internal func sendMessage(roomID: String, params: SendMessageParams) async throws(InternalError) -> Message {
         guard let clientId = realtime.clientId else {
             throw ARTErrorInfo.create(withCode: 40000, message: "Ensure your Realtime instance is initialized with a clientId.").toInternalError()
         }
 
-        let endpoint = "\(apiVersionV3)/rooms/\(roomId)/messages"
+        let endpoint = "\(apiVersionV3)/rooms/\(roomID)/messages"
         var body: [String: JSONValue] = ["text": .string(params.text)]
 
         // (CHA-M3b) A message may be sent without metadata or headers. When these are not specified by the user, they must be omitted from the REST payload.
@@ -67,7 +67,7 @@ internal final class ChatAPI: Sendable {
             serial: response.serial,
             action: .create,
             clientID: clientId,
-            roomID: roomId,
+            roomID: roomID,
             text: params.text,
             createdAt: createdAtDate,
             metadata: params.metadata ?? [:],
@@ -170,8 +170,8 @@ internal final class ChatAPI: Sendable {
         return message
     }
 
-    internal func getOccupancy(roomId: String) async throws(InternalError) -> OccupancyEvent {
-        let endpoint = "\(apiVersionV3)/rooms/\(roomId)/occupancy"
+    internal func getOccupancy(roomID: String) async throws(InternalError) -> OccupancyEvent {
+        let endpoint = "\(apiVersionV3)/rooms/\(roomID)/occupancy"
         return try await makeRequest(endpoint, method: "GET")
     }
 

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -1,0 +1,152 @@
+import Ably
+
+@MainActor
+internal final class DefaultMessageReactions: MessageReactions {
+    private let channel: any InternalRealtimeChannelProtocol
+    private let roomID: String
+    private let logger: InternalLogger
+    private let clientID: String
+    private let chatAPI: ChatAPI
+
+    private var defaultReaction: MessageReactionType
+
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomID: String, options: MessagesOptions, clientID: String, logger: InternalLogger) {
+        self.channel = channel
+        self.chatAPI = chatAPI
+        self.roomID = roomID
+        self.logger = logger
+        self.clientID = clientID
+        defaultReaction = options.defaultMessageReactionType
+    }
+
+    // (CHA-MR4) Users should be able to send a reaction to a message via the `send` method of the `MessagesReactions` object
+    internal func send(to messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo) {
+        do {
+            var count = params.count
+            if params.type == .multiple, params.count == nil {
+                count = 1
+            }
+
+            let apiParams: ChatAPI.SendMessageReactionParams = .init(
+                type: params.type ?? defaultReaction,
+                reaction: params.reaction,
+                count: count
+            )
+            let response = try await chatAPI.sendReactionToMessage(messageSerial, roomID: roomID, params: apiParams)
+
+            logger.log(message: "Added message reaction (annotation serial: \(response.serial))", level: .info)
+        } catch {
+            throw error.toARTErrorInfo()
+        }
+    }
+
+    // (CHA-MR11) Users should be able to delete a reaction from a message via the `delete` method of the `MessagesReactions` object
+    internal func delete(from messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
+        let reactionType = params.type ?? defaultReaction
+        if reactionType != .unique, params.reaction == nil {
+            throw ARTErrorInfo(chatError: .unableDeleteReactionWithoutName(reactionType: reactionType.rawValue))
+        }
+        do {
+            let apiParams: ChatAPI.DeleteMessageReactionParams = .init(
+                type: reactionType,
+                reaction: reactionType != .unique ? params.reaction : nil
+            )
+            let response = try await chatAPI.deleteReactionFromMessage(messageSerial, roomID: roomID, params: apiParams)
+
+            logger.log(message: "Deleted message reaction (annotation serial: \(response.serial))", level: .info)
+        } catch {
+            throw error.toARTErrorInfo()
+        }
+    }
+
+    // (CHA-MR6) Users must be able to subscribe to message reaction summaries via the subscribe method of the MessagesReactions object. The events emitted will be of type MessageReactionSummaryEvent.
+    @discardableResult
+    internal func subscribe(_ callback: @escaping @MainActor @Sendable (MessageReactionSummaryEvent) -> Void) -> SubscriptionProtocol {
+        logger.log(message: "Subscribing to message reaction summary events", level: .debug)
+
+        let eventListener = channel.subscribe { [logger] message in
+            do {
+                guard message.action == .messageSummary else {
+                    return
+                }
+
+                var summaryJson: [String: JSONValue]?
+                if let summaryData = message.summary {
+                    summaryJson = JSONValue(ablyCocoaData: summaryData).objectValue
+                }
+
+                guard let messageSerial = message.serial else {
+                    logger.log(message: "Received summary without serial: \(message)", level: .warn)
+                    return
+                }
+
+                let summaryEvent = try MessageReactionSummaryEvent(
+                    type: MessageReactionEvent.summary,
+                    summary: MessageReactionSummary(
+                        messageSerial: messageSerial,
+                        values: summaryJson ?? [:]
+                    )
+                )
+
+                logger.log(message: "Emitting reaction summary event: \(summaryEvent)", level: .debug)
+
+                callback(summaryEvent)
+            } catch {
+                logger.log(message: "Error processing incoming reaction message: \(error)", level: .error)
+            }
+        }
+
+        return Subscription { [weak self] in
+            self?.channel.unsubscribe(eventListener)
+        }
+    }
+
+    // (CHA-MR7) Users must be able to subscribe to raw message reactions (as individual annotations) via the subscribeRaw method of the MessagesReactions object. The events emitted are of type MessageReactionRawEvent.
+    @discardableResult
+    internal func subscribeRaw(_ callback: @escaping @MainActor @Sendable (MessageReactionRawEvent) -> Void) -> SubscriptionProtocol {
+        logger.log(message: "Subscribing to reaction events", level: .debug)
+
+        let eventListener = channel.annotations.subscribe { [clientID, logger] annotation in
+            logger.log(message: "Received reaction (message annotation): \(annotation)", level: .debug)
+            guard let annotationType = MessageReactionType(rawValue: annotation.type) else {
+                logger.log(message: "Received annotation without annotation's type: \(annotation)", level: .debug)
+                return
+            }
+
+            let reactionEventType = annotation.action == .delete ? MessageReactionEvent.delete : MessageReactionEvent.create
+
+            var reactionName = annotation.name
+            if reactionName == nil {
+                if reactionEventType == .delete, annotationType == .unique {
+                    // deletes of type unique are allowed to have no name
+                    reactionName = ""
+                } else {
+                    logger.log(message: "Received annotation without name: \(annotation)", level: .debug)
+                    return
+                }
+            }
+
+            let annotationClientID = annotation.clientId ?? ""
+
+            let reactionEvent = MessageReactionRawEvent(
+                type: reactionEventType,
+                timestamp: annotation.timestamp,
+                reaction: MessageReaction(
+                    type: annotationType,
+                    name: reactionName ?? "",
+                    messageSerial: annotation.messageSerial,
+                    count: annotation.count?.intValue ?? (annotation.action == .create && annotationType == .multiple ? 1 : nil),
+                    clientID: annotationClientID,
+                    isSelf: annotationClientID == clientID
+                )
+            )
+
+            logger.log(message: "Emitting message reaction event: \(reactionEvent)", level: .debug)
+
+            callback(reactionEvent)
+        }
+        return Subscription { [weak self] in
+            self?.channel.unsubscribe(eventListener)
+        }
+    }
+}

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -7,11 +7,14 @@ private struct MessageSubscriptionWrapper {
 }
 
 internal final class DefaultMessages: Messages {
+    internal let reactions: any MessageReactions
+
     private let channel: any InternalRealtimeChannelProtocol
     private let implementation: Implementation
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomID: String, clientID: String, logger: InternalLogger) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomID: String, options: MessagesOptions = .init(), clientID: String, logger: InternalLogger) {
         self.channel = channel
+        reactions = DefaultMessageReactions(channel: channel, chatAPI: chatAPI, roomID: roomID, options: options, clientID: clientID, logger: logger)
         implementation = .init(channel: channel, chatAPI: chatAPI, roomID: roomID, clientID: clientID, logger: logger)
     }
 

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -160,7 +160,7 @@ internal final class DefaultMessages: Messages {
         // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the “REST API”#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
         internal func get(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
             do {
-                return try await chatAPI.getMessages(roomId: roomID, params: options)
+                return try await chatAPI.getMessages(roomID: roomID, params: options)
             } catch {
                 throw error.toARTErrorInfo()
             }
@@ -168,7 +168,7 @@ internal final class DefaultMessages: Messages {
 
         internal func send(params: SendMessageParams) async throws(ARTErrorInfo) -> Message {
             do {
-                return try await chatAPI.sendMessage(roomId: roomID, params: params)
+                return try await chatAPI.sendMessage(roomID: roomID, params: params)
             } catch {
                 throw error.toARTErrorInfo()
             }
@@ -207,7 +207,7 @@ internal final class DefaultMessages: Messages {
             // (CHA-M5g) The subscribers subscription point must be additionally specified (internally, by us) in the fromSerial query parameter.
             queryOptions.fromSerial = subscriptionPoint
 
-            return try await chatAPI.getMessages(roomId: roomID, params: queryOptions)
+            return try await chatAPI.getMessages(roomID: roomID, params: queryOptions)
         }
 
         private func handleChannelEvents(roomId _: String) {

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -75,7 +75,7 @@ internal final class DefaultOccupancy: Occupancy {
         internal func get() async throws(ARTErrorInfo) -> OccupancyEvent {
             do {
                 logger.log(message: "Getting occupancy for room: \(roomID)", level: .debug)
-                return try await chatAPI.getOccupancy(roomId: roomID)
+                return try await chatAPI.getOccupancy(roomID: roomID)
             } catch {
                 throw error.toARTErrorInfo()
             }

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -11,6 +11,7 @@ internal final class DefaultRoomReactions: RoomReactions {
         try await implementation.send(params: params)
     }
 
+    @discardableResult
     internal func subscribe(_ callback: @escaping @MainActor (Reaction) -> Void) -> SubscriptionProtocol {
         implementation.subscribe(callback)
     }

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -28,12 +28,17 @@ public protocol RealtimeChannelsProtocol: ARTRealtimeChannelsProtocol, Sendable 
 /// Expresses the requirements of the object returned by ``RealtimeChannelsProtocol/get(_:options:)``.
 public protocol RealtimeChannelProtocol: ARTRealtimeChannelProtocol, Sendable {
     associatedtype Presence: RealtimePresenceProtocol
+    associatedtype Annotations: RealtimeAnnotationsProtocol
 
     var presence: Presence { get }
+    var annotations: Annotations { get }
 }
 
 /// Expresses the requirements of the object returned by ``RealtimeChannelProtocol/presence``.
 public protocol RealtimePresenceProtocol: ARTRealtimePresenceProtocol, Sendable {}
+
+/// Expresses the requirements of the object returned by ``RealtimeChannelProtocol/annotations``.
+public protocol RealtimeAnnotationsProtocol: ARTRealtimeAnnotationsProtocol, Sendable {}
 
 /// Expresses the requirements of the object returned by ``RealtimeClientProtocol/connection``.
 public protocol ConnectionProtocol: ARTConnectionProtocol, Sendable {}

--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -49,6 +49,8 @@ public enum ErrorCode: Int {
         case roomIsReleased
         case roomReleasedBeforeOperationCompleted
         case roomDiscontinuity
+        case unableDeleteReactionWithoutName
+        case cannotApplyEventForDifferentMessage
 
         internal var toNumericErrorCode: ErrorCode {
             switch self {
@@ -64,6 +66,10 @@ public enum ErrorCode: Int {
                 .roomReleasedBeforeOperationCompleted
             case .roomDiscontinuity:
                 .roomDiscontinuity
+            case .unableDeleteReactionWithoutName:
+                .badRequest
+            case .cannotApplyEventForDifferentMessage:
+                .badRequest
             }
         }
 
@@ -75,7 +81,9 @@ public enum ErrorCode: Int {
                  .roomInFailedState,
                  .roomIsReleasing,
                  .roomIsReleased,
-                 .roomReleasedBeforeOperationCompleted:
+                 .roomReleasedBeforeOperationCompleted,
+                 .unableDeleteReactionWithoutName,
+                 .cannotApplyEventForDifferentMessage:
                 400
             case .roomDiscontinuity:
                 500
@@ -139,6 +147,8 @@ internal enum ChatError {
     case presenceOperationRequiresRoomAttach(feature: RoomFeature)
     case roomTransitionedToInvalidStateForPresenceOperation(cause: ARTErrorInfo?)
     case roomDiscontinuity(cause: ARTErrorInfo?)
+    case unableDeleteReactionWithoutName(reactionType: String)
+    case cannotApplyEventForDifferentMessage
 
     internal var codeAndStatusCode: ErrorCodeAndStatusCode {
         switch self {
@@ -163,6 +173,10 @@ internal enum ChatError {
             .variableStatusCode(.roomInInvalidState, statusCode: 400)
         case .roomDiscontinuity:
             .fixedStatusCode(.roomDiscontinuity)
+        case .unableDeleteReactionWithoutName:
+            .fixedStatusCode(.unableDeleteReactionWithoutName)
+        case .cannotApplyEventForDifferentMessage:
+            .fixedStatusCode(.cannotApplyEventForDifferentMessage)
         }
     }
 
@@ -209,6 +223,10 @@ internal enum ChatError {
             "The room operation failed because the room was in an invalid state."
         case .roomDiscontinuity:
             "The room has experienced a discontinuity."
+        case let .unableDeleteReactionWithoutName(reactionType: reactionType):
+            "Cannot delete reaction of type '\(reactionType)' without a reaction name."
+        case .cannotApplyEventForDifferentMessage:
+            "Cannot apply event for different message."
         }
     }
 
@@ -225,7 +243,9 @@ internal enum ChatError {
              .roomIsReleasing,
              .roomIsReleased,
              .roomReleasedBeforeOperationCompleted,
-             .presenceOperationRequiresRoomAttach:
+             .presenceOperationRequiresRoomAttach,
+             .cannotApplyEventForDifferentMessage,
+             .unableDeleteReactionWithoutName:
             nil
         }
     }

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -20,7 +20,7 @@ public enum MessageAction: String, Sendable {
         case .delete:
             .delete
         // ignore any other actions except `message.create` for now
-        case .metaOccupancy,
+        case .meta,
              .messageSummary:
             nil
         @unknown default:

--- a/Sources/AblyChat/MessageReaction+JSON.swift
+++ b/Sources/AblyChat/MessageReaction+JSON.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+internal extension MessageReactionSummary {
+    enum JSONKey: String {
+        case messageSerial
+        case unique
+        case distinct
+        case multiple
+    }
+
+    init(messageSerial: String, values jsonObject: [String: JSONValue]) throws(InternalError) {
+        self.messageSerial = messageSerial
+
+        // Two different key are used for now until fixed. Internal discussion:
+        // https://ably-real-time.slack.com/archives/C02NY1VT3LY/p1749924228762039?thread_ts=1749655305.091679&cid=C02NY1VT3LY
+        let uniqueJson = try? jsonObject.optionalObjectValueForKey(MessageReactionType.unique.rawValue) ??
+            jsonObject.optionalObjectValueForKey("unique")
+        if let uniqueJson {
+            do {
+                unique = try uniqueJson.mapValues { value in
+                    guard let uniqueJsonItem = value.objectValue else {
+                        throw JSONValueDecodingError.noValueForKey("unique.<key>").toInternalError()
+                    }
+                    return try MessageReactionSummary.ClientIdList(jsonObject: uniqueJsonItem)
+                }
+            } catch {
+                throw JSONValueDecodingError.failedToDecodeFromRawValue("unique: \(uniqueJson)").toInternalError()
+            }
+        } else {
+            unique = [:]
+        }
+
+        let distinctJson = try? jsonObject.optionalObjectValueForKey(MessageReactionType.distinct.rawValue) ??
+            jsonObject.optionalObjectValueForKey("distinct")
+        if let distinctJson {
+            do {
+                distinct = try distinctJson.mapValues { value in
+                    guard let distinctJsonItem = value.objectValue else {
+                        throw JSONValueDecodingError.noValueForKey("unique.<key>").toInternalError()
+                    }
+                    return try MessageReactionSummary.ClientIdList(jsonObject: distinctJsonItem)
+                }
+            } catch {
+                throw JSONValueDecodingError.failedToDecodeFromRawValue("unique: \(distinctJson)").toInternalError()
+            }
+        } else {
+            distinct = [:]
+        }
+
+        let multipleJson = try? jsonObject.optionalObjectValueForKey(MessageReactionType.multiple.rawValue) ??
+            jsonObject.optionalObjectValueForKey("multiple")
+        if let multipleJson {
+            do {
+                multiple = try multipleJson.mapValues { value in
+                    guard let multipleJsonItem = value.objectValue else {
+                        throw JSONValueDecodingError.noValueForKey("unique.<key>").toInternalError()
+                    }
+                    return try MessageReactionSummary.ClientIdCounts(jsonObject: multipleJsonItem)
+                }
+            } catch {
+                throw JSONValueDecodingError.failedToDecodeFromRawValue("unique: \(multipleJson)").toInternalError()
+            }
+        } else {
+            multiple = [:]
+        }
+    }
+}
+
+extension MessageReactionSummary.ClientIdList: JSONObjectDecodable {
+    internal enum JSONKey: String {
+        case total
+        case clientIds
+    }
+
+    internal init(jsonObject: [String: JSONValue]) throws(InternalError) {
+        total = try UInt(jsonObject.numberValueForKey(JSONKey.total.rawValue))
+        clientIds = try jsonObject.arrayValueForKey(JSONKey.clientIds.rawValue).compactMap(\.stringValue)
+    }
+}
+
+extension MessageReactionSummary.ClientIdCounts: JSONObjectDecodable {
+    internal enum JSONKey: String {
+        case total
+        case clientIds
+    }
+
+    internal init(jsonObject: [String: JSONValue]) throws(InternalError) {
+        total = try UInt(jsonObject.numberValueForKey(JSONKey.total.rawValue))
+        clientIds = try jsonObject.objectValueForKey(JSONKey.clientIds.rawValue).mapValues { UInt($0.numberValue ?? 0) }
+    }
+}

--- a/Sources/AblyChat/MessageReaction.swift
+++ b/Sources/AblyChat/MessageReaction.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+/**
+ * Enum representing different message reaction events in the chat system.
+ */
+public enum MessageReactionEvent: String, Sendable {
+    /**
+     * A reaction was added to a message.
+     */
+    case create = "reaction.create"
+    /**
+     * A reaction was removed from a message.
+     */
+    case delete = "reaction.delete"
+    /**
+     * A reactions summary was updated for a message.
+     */
+    case summary = "reaction.summary"
+}
+
+/**
+ * Represents a message-level reaction.
+ */
+public struct MessageReaction: Sendable {
+    /**
+     * The reaction type (Unique, Distinct, or Multiple).
+     */
+    public var type: MessageReactionType
+    /**
+     * The reaction itself, typically an emoji.
+     */
+    public var name: String
+
+    /**
+     * The serial of the message, for which this reaction was created.
+     */
+    public var messageSerial: String
+
+    /**
+     * An optional count field for reactions of type "multiple".
+     */
+    public var count: Int?
+
+    /**
+     * The clientId of the user who sent the reaction.
+     */
+    public var clientID: String
+
+    /**
+     * Whether the reaction was sent by the current user.
+     */
+    public var isSelf: Bool
+
+    public init(type: MessageReactionType, name: String, messageSerial: String, count: Int? = nil, clientID: String, isSelf: Bool) {
+        self.type = type
+        self.name = name
+        self.messageSerial = messageSerial
+        self.count = count
+        self.clientID = clientID
+        self.isSelf = isSelf
+    }
+}
+
+/**
+ * All annotation types supported by Chat Message Reactions.
+ */
+public enum MessageReactionType: String, Sendable {
+    /**
+     * Allows for at most one reaction per client per message. If a client reacts
+     * to a message a second time, only the second reaction is counted in the
+     * summary.
+     *
+     * This is similar to reactions on iMessage, Facebook Messenger or WhatsApp.
+     */
+    case unique = "reaction:unique.v1"
+
+    /**
+     * Allows for at most one reaction of each type per client per message. It is
+     * possible for a client to add multiple reactions to the same message as
+     * long as they are different (eg different emojis). Duplicates are not
+     * counted in the summary.
+     *
+     * This is similar to reactions on Slack.
+     */
+    case distinct = "reaction:distinct.v1"
+
+    /**
+     * Allows any number of reactions, including repeats, and they are counted in
+     * the summary. The reaction payload also includes a count of how many times
+     * each reaction should be counted (defaults to 1 if not set).
+     *
+     * This is similar to the clap feature on Medium or how room reactions work.
+     */
+    case multiple = "reaction:multiple.v1"
+}
+
+/**
+ * Represents a summary of all reactions on a message.
+ */
+public struct MessageReactionSummary: Sendable, Equatable {
+    /**
+     * Map of reaction to the summary (total and clients) for reactions of type ``MessageReactionType/unique`` and ``MessageReactionType/distinct``.
+     */
+    public struct ClientIdList: Sendable, Equatable {
+        /**
+         * Total amount of reactions of a given type.
+         */
+        public var total: UInt
+
+        /**
+         * List of clients who left given reaction type.
+         */
+        public var clientIds: [String]
+    }
+
+    /**
+     * Map of reaction to the summary (total and clients) for reactions of type ``MessageReactionType/multiple``.
+     */
+    public struct ClientIdCounts: Sendable, Equatable {
+        /**
+         * Total amount of reactions of a given type.
+         */
+        public var total: UInt
+
+        /**
+         * Map of clients who left given reaction type number of times.
+         */
+        public var clientIds: [String: UInt]
+    }
+
+    /**
+     * Reference to the original message's serial.
+     */
+    public var messageSerial: String
+
+    /**
+     * Map of unique-type reactions summaries.
+     */
+    public var unique: [String: ClientIdList]
+
+    /**
+     * Map of distinct-type reactions summaries.
+     */
+    public var distinct: [String: ClientIdList]
+
+    /**
+     * Map of multiple-type reactions summaries.
+     */
+    public var multiple: [String: ClientIdCounts]
+}
+
+/**
+ * Event interface representing a summary of message reactions.
+ * This event aggregates different types of reactions (single, distinct, multiple) for a specific message.
+ */
+public struct MessageReactionSummaryEvent: Sendable, Equatable {
+    /**
+     * The type of the event (should be equal to summary).
+     */
+    public var type: MessageReactionEvent
+
+    /**
+     * The message reactions summary.
+     */
+    public var summary: MessageReactionSummary
+}
+
+/**
+ * Represents an individual message reaction event.
+ */
+public struct MessageReactionRawEvent: Sendable {
+    /**
+     * Whether reaction was added or removed.
+     */
+    public var type: MessageReactionEvent
+
+    /**
+     * The timestamp of this event.
+     */
+    public var timestamp: Date?
+
+    /**
+     * The message reaction that was received.
+     */
+    public var reaction: MessageReaction
+}

--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -1,0 +1,163 @@
+import Ably
+
+/**
+ * Add, delete, and subscribe to message reactions.
+ *
+ * Get an instance via ``Room/messages/reactions``.
+ */
+@MainActor
+public protocol MessageReactions: AnyObject, Sendable {
+    /**
+     * Add a message reaction.
+     *
+     * - Parameters:
+     *   - messageSerial: A serial of the message to react to.
+     *   - params: Describe the reaction to add.
+     *
+     * - Note: It is possible to receive your own reaction via the reactions subscription before this method returns.
+     */
+    func send(to messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo)
+
+    /**
+     * Delete a message reaction.
+     *
+     * - Parameters:
+     *   - messageSerial: A serial of the message to remove the reaction from.
+     *   - params: The type of reaction annotation and the specific reaction to remove. The reaction to remove is required for all types except ``MessageReactionType/unique``.
+     */
+    func delete(from messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo)
+
+    /**
+     * Subscribe to message reaction summaries. Use this to keep message reaction counts up to date efficiently in the UI.
+     *
+     * - Parameters:
+     *   - callback: A callback to call when a message reaction summary is received.
+     *
+     * - Returns: A subscription handle object that should be used to unsubscribe.
+     */
+    @discardableResult
+    func subscribe(_ callback: @escaping @MainActor (MessageReactionSummaryEvent) -> Void) -> SubscriptionProtocol
+
+    /**
+     * Subscribe to individual reaction events.
+     *
+     * - Parameters:
+     *   - callback: A callback to call when a message reaction event is received.
+     *
+     * - Returns: A subscription handle object that should be used to unsubscribe.
+     *
+     * - Note: If you only need to keep track of reaction counts and clients, use ``subscribe(_:)`` instead.
+     */
+    @discardableResult
+    func subscribeRaw(_ callback: @escaping @MainActor (MessageReactionRawEvent) -> Void) -> SubscriptionProtocol
+}
+
+/// `AsyncSequence` variant of receiving message reactions events.
+public extension MessageReactions {
+    /**
+     * Subscribes a given listener to message reactions summary events.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``MessageReactionSummaryEvent`` events.
+     */
+    func subscribe(bufferingPolicy: BufferingPolicy) -> SubscriptionAsyncSequence<MessageReactionSummaryEvent> {
+        let subscriptionAsyncSequence = SubscriptionAsyncSequence<MessageReactionSummaryEvent>(bufferingPolicy: bufferingPolicy)
+
+        let subscription = subscribe { summaryEvent in
+            subscriptionAsyncSequence.emit(summaryEvent)
+        }
+
+        subscriptionAsyncSequence.addTerminationHandler {
+            Task { @MainActor in
+                subscription.unsubscribe()
+            }
+        }
+
+        return subscriptionAsyncSequence
+    }
+
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
+    func subscribe() -> SubscriptionAsyncSequence<MessageReactionSummaryEvent> {
+        subscribe(bufferingPolicy: .unbounded)
+    }
+
+    /**
+     * Subscribes a given listener to message reactions events.
+     *
+     * - Parameters:
+     *   - bufferingPolicy: The ``BufferingPolicy`` for the created subscription.
+     *
+     * - Returns: A subscription `AsyncSequence` that can be used to iterate through ``MessageReactionRawEvent`` events.
+     */
+    func subscribeRaw(bufferingPolicy: BufferingPolicy) -> SubscriptionAsyncSequence<MessageReactionRawEvent> {
+        let subscriptionAsyncSequence = SubscriptionAsyncSequence<MessageReactionRawEvent>(bufferingPolicy: bufferingPolicy)
+
+        let subscription = subscribeRaw { reaction in
+            subscriptionAsyncSequence.emit(reaction)
+        }
+
+        subscriptionAsyncSequence.addTerminationHandler {
+            Task { @MainActor in
+                subscription.unsubscribe()
+            }
+        }
+
+        return subscriptionAsyncSequence
+    }
+
+    /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
+    func subscribeRaw() -> SubscriptionAsyncSequence<MessageReactionRawEvent> {
+        subscribeRaw(bufferingPolicy: .unbounded)
+    }
+}
+
+/**
+ * Parameters for adding a message reaction.
+ */
+public struct SendMessageReactionParams: Sendable {
+    /**
+     * The type of reaction, must be one of ``MessageReactionType``.
+     * If not set, the default type will be used which is configured in the ``MessagesOptions/defaultMessageReactionType`` of the room.
+     */
+    public var type: MessageReactionType?
+
+    /**
+     * The reaction to add; ie. the emoji.
+     */
+    public var reaction: String
+
+    /**
+     * The count of the reaction for type ``MessageReactionType/multiple``.
+     * Defaults to 1 if not set. Not supported for other reaction types.
+     */
+    public var count: Int?
+
+    public init(reaction: String, type: MessageReactionType? = nil, count: Int? = nil) {
+        self.reaction = reaction
+        self.type = type
+        self.count = count
+    }
+}
+
+/**
+ * Parameters for deleting a message reaction.
+ */
+public struct DeleteMessageReactionParams: Sendable {
+    /**
+     * The type of reaction, must be one of ``MessageReactionType``.
+     */
+    public var type: MessageReactionType?
+
+    /**
+     * The reaction to remove, ie. the emoji. Required for all reaction types
+     * except ``MessageReactionType/unique``.
+     */
+    public var reaction: String?
+
+    public init(reaction: String? = nil, type: MessageReactionType? = nil) {
+        self.reaction = reaction
+        self.type = type
+    }
+}

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -72,6 +72,11 @@ public protocol Messages: AnyObject, Sendable {
      * - Note: It is possible to receive your own message via the messages subscription before this method returns.
      */
     func delete(message: Message, params: DeleteMessageParams) async throws(ARTErrorInfo) -> Message
+
+    /**
+     * Add, delete, and subscribe to message reactions.
+     */
+    var reactions: MessageReactions { get }
 }
 
 public extension Messages {

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -279,6 +279,7 @@ internal class DefaultRoom: InternalRoom {
             channel: internalChannel,
             chatAPI: chatAPI,
             roomID: roomID,
+            options: options.messages,
             clientID: clientId,
             logger: logger
         )
@@ -323,16 +324,23 @@ internal class DefaultRoom: InternalRoom {
         // CHA-GP2a
         channelOptions.attachOnSubscribe = false
 
+        // Initial modes (CHA-RC3d)
+        channelOptions.modes = [.publish, .subscribe, .presence, .annotationPublish]
+
         // CHA-RC3a (Multiple features share a realtime channel. We fetch the channel exactly once, merging the channel options for the various features.)
-        if !roomOptions.presence.enableEvents {
-            // CHA-PR9c2
-            channelOptions.modes = [.publish, .subscribe, .presence]
+        if roomOptions.presence.enableEvents {
+            // CHA-RC3d1
+            channelOptions.modes.insert(.presenceSubscribe)
         }
         if roomOptions.occupancy.enableEvents {
             // CHA-O6a, CHA-O6b
             var params: [String: String] = channelOptions.params ?? [:]
             params["occupancy"] = "metrics"
             channelOptions.params = params
+        }
+        if roomOptions.messages.rawMessageReactions {
+            // CHA-RC3d2
+            channelOptions.modes.insert(.annotationSubscribe)
         }
 
         // CHA-RC3c

--- a/Sources/AblyChat/RoomOptions.swift
+++ b/Sources/AblyChat/RoomOptions.swift
@@ -24,7 +24,13 @@ public struct RoomOptions: Sendable, Equatable {
      */
     public var occupancy = OccupancyOptions()
 
-    public init(presence: PresenceOptions = PresenceOptions(), typing: TypingOptions = TypingOptions(), reactions: RoomReactionsOptions = RoomReactionsOptions(), occupancy: OccupancyOptions = OccupancyOptions()) {
+    /**
+     * The message options for the room. Messages are always enabled, this object is for additional configuration.
+     */
+    public var messages = MessagesOptions()
+
+    public init(messages: MessagesOptions = MessagesOptions(), presence: PresenceOptions = PresenceOptions(), typing: TypingOptions = TypingOptions(), reactions: RoomReactionsOptions = RoomReactionsOptions(), occupancy: OccupancyOptions = OccupancyOptions()) {
+        self.messages = messages
         self.presence = presence
         self.typing = typing
         self.reactions = reactions
@@ -47,6 +53,36 @@ public struct PresenceOptions: Sendable, Equatable {
 
     public init(enableEvents: Bool = true) {
         self.enableEvents = enableEvents
+    }
+}
+
+/**
+ * Represents the messages options for a chat room.
+ */
+public struct MessagesOptions: Sendable, Equatable {
+    /**
+     * Whether to enable receiving raw individual message reactions from the
+     * realtime channel. Set to true if subscribing to raw message reactions.
+     *
+     * Note reaction summaries (aggregates) are always available regardless of
+     * this setting.
+     *
+     * Defaults to false.
+     */
+    public var rawMessageReactions = false
+
+    /**
+     * The default message reaction type to use for sending message reactions.
+     *
+     * Any message reaction type can be sent regardless of this setting by specifying the `type` parameter in the ``MessageReactions/add(for:params:)`` method.
+     *
+     * Defaults to ``MessageReactionType/distinct``
+     */
+    public var defaultMessageReactionType = MessageReactionType.distinct
+
+    public init(rawMessageReactions: Bool = false, defaultMessageReactionType: MessageReactionType = .distinct) {
+        self.rawMessageReactions = rawMessageReactions
+        self.defaultMessageReactionType = defaultMessageReactionType
     }
 }
 

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -13,12 +13,12 @@ struct ChatAPITests {
             MockHTTPPaginatedResponse.successSendMessageWithNoItems
         }
         let chatAPI = ChatAPI(realtime: realtime)
-        let roomId = "basketball"
+        let roomID = "basketball"
 
         await #expect(
             performing: {
                 // When
-                try await chatAPI.sendMessage(roomId: roomId, params: .init(text: "hello", headers: [:]))
+                try await chatAPI.sendMessage(roomID: roomID, params: .init(text: "hello", headers: [:]))
             }, throws: { error in
                 // Then
                 if let internalError = error as? InternalError, case .other(.chatAPIChatError(.noItemInResponse)) = internalError {
@@ -38,17 +38,17 @@ struct ChatAPITests {
             MockHTTPPaginatedResponse.successSendMessage
         }
         let chatAPI = ChatAPI(realtime: realtime)
-        let roomId = "basketball"
+        let roomID = "basketball"
 
         // When
-        let message = try await chatAPI.sendMessage(roomId: roomId, params: .init(text: "hello", headers: [:]))
+        let message = try await chatAPI.sendMessage(roomID: roomID, params: .init(text: "hello", headers: [:]))
 
         // Then
         let expectedMessage = Message(
             serial: "3446456",
             action: .create,
             clientID: "mockClientId",
-            roomID: roomId,
+            roomID: roomID,
             text: "hello",
             createdAt: Date(timeIntervalSince1970: 1_631_840_000),
             metadata: [:],
@@ -69,7 +69,7 @@ struct ChatAPITests {
 
         // When
         _ = try await chatAPI.sendMessage(
-            roomId: "", // arbitrary
+            roomID: "", // arbitrary
             params: .init(
                 text: "", // arbitrary
                 // The exact value here is arbitrary, just want to check it gets serialized
@@ -92,7 +92,7 @@ struct ChatAPITests {
 
         // When
         _ = try await chatAPI.sendMessage(
-            roomId: "", // arbitrary
+            roomID: "", // arbitrary
             params: .init(
                 text: "", // arbitrary
                 // The exact value here is arbitrary, just want to check it gets serialized
@@ -116,14 +116,14 @@ struct ChatAPITests {
             paginatedResponse
         }
         let chatAPI = ChatAPI(realtime: realtime)
-        let roomId = "basketball"
+        let roomID = "basketball"
         let expectedPaginatedResult = PaginatedResultWrapper<Message>(
             paginatedResponse: paginatedResponse,
             items: []
         )
 
         // When
-        let getMessages = try? await chatAPI.getMessages(roomId: roomId, params: .init()) as? PaginatedResultWrapper<Message>
+        let getMessages = try? await chatAPI.getMessages(roomID: roomID, params: .init()) as? PaginatedResultWrapper<Message>
 
         // Then
         #expect(getMessages == expectedPaginatedResult)
@@ -138,7 +138,7 @@ struct ChatAPITests {
             paginatedResponse
         }
         let chatAPI = ChatAPI(realtime: realtime)
-        let roomId = "basketball"
+        let roomID = "basketball"
         let expectedPaginatedResult = PaginatedResultWrapper<Message>(
             paginatedResponse: paginatedResponse,
             items: [
@@ -146,7 +146,7 @@ struct ChatAPITests {
                     serial: "3446456",
                     action: .create,
                     clientID: "random",
-                    roomID: roomId,
+                    roomID: roomID,
                     text: "hello",
                     createdAt: .init(timeIntervalSince1970: 1_730_943_049.269),
                     metadata: [:],
@@ -158,7 +158,7 @@ struct ChatAPITests {
                     serial: "3446457",
                     action: .create,
                     clientID: "random",
-                    roomID: roomId,
+                    roomID: roomID,
                     text: "hello response",
                     createdAt: nil,
                     metadata: [:],
@@ -170,7 +170,7 @@ struct ChatAPITests {
         )
 
         // When
-        let getMessagesResult = try? await chatAPI.getMessages(roomId: roomId, params: .init()) as? PaginatedResultWrapper<Message>
+        let getMessagesResult = try? await chatAPI.getMessages(roomID: roomID, params: .init()) as? PaginatedResultWrapper<Message>
 
         // Then
         #expect(getMessagesResult == expectedPaginatedResult)
@@ -185,12 +185,12 @@ struct ChatAPITests {
             throw artError
         }
         let chatAPI = ChatAPI(realtime: realtime)
-        let roomId = "basketball"
+        let roomID = "basketball"
 
         await #expect(
             performing: {
                 // When
-                try await chatAPI.getMessages(roomId: roomId, params: .init()) as? PaginatedResultWrapper<Message>
+                try await chatAPI.getMessages(roomID: roomID, params: .init()) as? PaginatedResultWrapper<Message>
             }, throws: { error in
                 // Then
                 isInternalErrorWrappingErrorInfo(error, artError)

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -1,0 +1,97 @@
+import Ably
+@testable import AblyChat
+import Testing
+
+@MainActor
+struct DefaultMessageReactionsTests {
+    // @spec CHA-MR6
+    @Test
+    func subscribeToMessageReactionSummaries() async throws {
+        // Given
+        let realtime = MockRealtime()
+        let chatAPI = ChatAPI(realtime: realtime)
+
+        let channel = MockRealtimeChannel(
+            properties: .init(
+                attachSerial: "001",
+                channelSerial: "001"
+            ),
+            initialState: .attached,
+            messageToEmitOnSubscribe: {
+                let message = ARTMessage()
+                message.serial = "001"
+                message.action = .messageSummary
+                message.summary = [
+                    "reaction:unique.v1": [
+                        "like": ["total": 2, "clientIds": ["userOne", "userTwo"]],
+                        "love": ["total": 1, "clientIds": ["userThree"]],
+                    ],
+                    "reaction:distinct.v1": [
+                        "like": ["total": 2, "clientIds": ["userOne", "userTwo"]],
+                        "love": ["total": 1, "clientIds": ["userOne"]],
+                    ],
+                    "reaction:multiple.v1": [
+                        "like": ["total": 5, "clientIds": ["userOne": 3, "userTwo": 2]],
+                        "love": ["total": 10, "clientIds": ["userOne": 10]],
+                    ],
+                ]
+                return message
+            }()
+        )
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomID: "basketball", clientID: "clientId", logger: TestLogger())
+
+        // When
+        defaultMessages.reactions.subscribe { event in
+            // Then
+            #expect(event.type == .summary)
+            #expect(event.summary.unique["like"]?.total == 2)
+            #expect(event.summary.unique["love"]?.total == 1)
+            #expect(event.summary.distinct["like"]?.total == 2)
+            #expect(event.summary.distinct["love"]?.total == 1)
+            #expect(event.summary.multiple["like"]?.total == 5)
+            #expect(event.summary.multiple["love"]?.total == 10)
+        }
+    }
+
+    // @spec CHA-MR7
+    @Test
+    func subscribeToRawMessageReactions() async throws {
+        // Given
+        let realtime = MockRealtime()
+        let chatAPI = ChatAPI(realtime: realtime)
+
+        let channel = MockRealtimeChannel(
+            properties: .init(
+                attachSerial: "001",
+                channelSerial: "001"
+            ),
+            initialState: .attached,
+            annotationToEmitOnSubscribe: .init(
+                id: nil,
+                action: .create,
+                clientId: "U3BpZGVyd2Vi",
+                name: "🔥",
+                count: 41,
+                data: nil,
+                encoding: nil,
+                timestamp: Date(),
+                serial: "",
+                messageSerial: "0LHQtdC70YvQtSDRgNC+0LfRiw",
+                type: "reaction:multiple.v1",
+                extras: nil
+            )
+        )
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomID: "basketball", clientID: "clientId", logger: TestLogger())
+
+        // When
+        defaultMessages.reactions.subscribeRaw { event in
+            // Then
+            #expect(event.type == MessageReactionEvent.create)
+            #expect(event.reaction.type == .multiple)
+            #expect(event.reaction.name == "🔥")
+            #expect(event.reaction.clientID == "U3BpZGVyd2Vi")
+            #expect(event.reaction.messageSerial == "0LHQtdC70YvQtSDRgNC+0LfRiw")
+            #expect(event.reaction.count == 41)
+        }
+    }
+}

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -29,20 +29,73 @@ struct DefaultRoomReactionsTests {
         #expect(channel.publishedMessages.last?.extras == ["headers": ["someHeadersKey": "someHeadersValue"], "ephemeral": true])
     }
 
-    // @spec CHA-ER4
+    // @spec CHA-ER4a
+    // @spec CHA-ER4b
     @Test
-    func subscribe_returnsSubscription() async throws {
-        // all setup values here are arbitrary
+    func subscriptionCanBeRegisteredToReceiveReactionEvents() async throws {
         // Given
-        let channel = MockRealtimeChannel(name: "basketball::$chat")
+        func generateMessage(serial: String, reactionType: String) -> ARTMessage {
+            let message = ARTMessage()
+            message.action = .create // arbitrary
+            message.serial = serial // arbitrary
+            message.clientId = "" // arbitrary
+            message.data = [
+                "type": reactionType,
+            ]
+            message.version = "0"
+            return message
+        }
 
-        // When
+        let channel = MockRealtimeChannel(
+            messageToEmitOnSubscribe: generateMessage(serial: "1", reactionType: ":like:")
+        )
         let defaultRoomReactions = DefaultRoomReactions(channel: channel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
 
         // When
-        let subscription: SubscriptionAsyncSequence<Reaction>? = defaultRoomReactions.subscribe()
+        let subscription = defaultRoomReactions.subscribe { reaction in
+            // Then
+            #expect(reaction.type == ":like:")
+        }
 
-        // Then
-        #expect(subscription != nil)
+        // CHA-ER4b
+        subscription.unsubscribe()
+
+        // will not be received and expectations above will not fail
+        channel.simulateIncomingMessage(
+            generateMessage(serial: "2", reactionType: ":dislike:"),
+            for: RoomReactionEvents.reaction.rawValue
+        )
+    }
+
+    // CHA-ER4c is currently untestable due to not subscribing to those events on lower level
+    // @spec CHA-ER4d
+    @Test
+    func malformedRealtimeEventsShallNotBeEmittedToSubscribers() async throws {
+        // Given
+        let channel = MockRealtimeChannel(
+            messageToEmitOnSubscribe: {
+                let message = ARTMessage()
+                message.action = .create // arbitrary
+                message.serial = "123" // arbitrary
+                message.clientId = "" // arbitrary
+                message.data = [
+                    "type": ":like:",
+                ]
+                message.extras = [:] as any ARTJsonCompatible
+                message.version = "0"
+                return message
+            }()
+        )
+        let defaultRoomReactions = DefaultRoomReactions(channel: channel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
+
+        // When
+        defaultRoomReactions.subscribe { reaction in
+            #expect(reaction.type == ":like:")
+        }
+        // will not be received and expectations above will not fail
+        channel.simulateIncomingMessage(
+            ARTMessage(), // malformed message
+            for: RealtimeMessageName.chatMessage.rawValue
+        )
     }
 }

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -56,7 +56,7 @@ struct DefaultRoomTests {
 
         let chatMessagesChannelGetOptions = try #require(channelsGetArguments.first { $0.name == "basketball::$chat" }?.options)
         #expect(chatMessagesChannelGetOptions.params?["occupancy"] == "metrics")
-        #expect(chatMessagesChannelGetOptions.modes == [.publish, .subscribe, .presence])
+        #expect(chatMessagesChannelGetOptions.modes == [.publish, .subscribe, .presence, .annotationPublish])
     }
 
     // @spec CHA-O6a
@@ -94,11 +94,11 @@ struct DefaultRoomTests {
             (
                 enableEvents: true,
                 // i.e. it doesn't explicitly set any modes (so that Realtime will use the default modes)
-                expectedChannelModes: [] as ARTChannelMode
+                expectedChannelModes: [.publish, .subscribe, .presence, .annotationPublish, .presenceSubscribe] as ARTChannelMode
             ),
             (
                 enableEvents: false,
-                expectedChannelModes: [.publish, .subscribe, .presence] as ARTChannelMode
+                expectedChannelModes: [.publish, .subscribe, .presence, .annotationPublish] as ARTChannelMode
             ),
         ]
     )

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -82,6 +82,7 @@ struct IntegrationTests {
         let rxRoom = try await rxClient.rooms.get(
             roomID: roomID,
             options: .init(
+                messages: .init(rawMessageReactions: true),
                 presence: .init(),
                 typing: .init(heartbeatThrottle: 2),
                 reactions: .init(),
@@ -133,6 +134,88 @@ struct IntegrationTests {
         let rxMessageFromSubscription = try #require(await rxMessageSubscription.first { @Sendable _ in true })
         #expect(rxMessageFromSubscription == txMessageAfterRxSubscribe)
 
+        // MARK: - Message Reactions (Summary)
+
+        let messageToReact = txMessageBeforeRxSubscribe
+
+        let rxMessageReactionsSubscription = rxRoom.messages.reactions.subscribe()
+
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "👍"))
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "🎉"))
+        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(reaction: "👍"))
+        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(reaction: "🎉"))
+
+        var reactionSummaryEvents = [MessageReactionSummaryEvent]()
+
+        for await event in rxMessageReactionsSubscription {
+            reactionSummaryEvents.append(event)
+            if reactionSummaryEvents.count == 4 {
+                break
+            }
+        }
+
+        #expect(reactionSummaryEvents[0].summary.messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[0].summary.unique.isEmpty)
+        #expect(reactionSummaryEvents[0].summary.multiple.isEmpty)
+        #expect(reactionSummaryEvents[0].summary.distinct.count == 1)
+        _ = reactionSummaryEvents[0].summary.distinct.map { key, value in
+            #expect(key == "👍")
+            #expect(value.total == 1)
+            #expect(value.clientIds == [messageToReact.clientID])
+        }
+
+        #expect(reactionSummaryEvents[1].summary.messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[1].summary.unique.isEmpty)
+        #expect(reactionSummaryEvents[1].summary.multiple.isEmpty)
+        #expect(reactionSummaryEvents[1].summary.distinct.count == 2)
+
+        #expect(reactionSummaryEvents[2].summary.messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[2].summary.unique.isEmpty)
+        #expect(reactionSummaryEvents[2].summary.multiple.isEmpty)
+        #expect(reactionSummaryEvents[2].summary.distinct.count == 1)
+        _ = reactionSummaryEvents[2].summary.distinct.map { key, value in
+            #expect(key == "🎉")
+            #expect(value.total == 1)
+            #expect(value.clientIds == [messageToReact.clientID])
+        }
+
+        #expect(reactionSummaryEvents[3].summary.messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[3].summary.unique.isEmpty)
+        #expect(reactionSummaryEvents[3].summary.multiple.isEmpty)
+        #expect(reactionSummaryEvents[3].summary.distinct.isEmpty)
+
+        // MARK: - Message Reactions (Raw)
+
+        let rxMessageRawReactionsSubscription = rxRoom.messages.reactions.subscribeRaw()
+
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "🔥"))
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "😆"))
+        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(reaction: "😆")) // not deleting 🔥 to check it later in history request
+
+        var reactionRawEvents = [MessageReactionRawEvent]()
+
+        for await event in rxMessageRawReactionsSubscription {
+            reactionRawEvents.append(event)
+            if reactionRawEvents.count == 3 {
+                break
+            }
+        }
+
+        #expect(reactionRawEvents[0].type == .create)
+        #expect(reactionRawEvents[0].reaction.name == "🔥")
+        #expect(reactionRawEvents[0].reaction.messageSerial == messageToReact.serial)
+
+        #expect(reactionRawEvents[1].type == .create)
+        #expect(reactionRawEvents[1].reaction.name == "😆")
+        #expect(reactionRawEvents[1].reaction.messageSerial == messageToReact.serial)
+
+        #expect(reactionRawEvents[2].type == .delete)
+        #expect(reactionRawEvents[2].reaction.name == "😆")
+        #expect(reactionRawEvents[2].reaction.messageSerial == messageToReact.serial)
+
+        // Wait a little before requesting history
+        try await Task.sleep(nanoseconds: 2 * NSEC_PER_SEC)
+
         // (7) Fetch historical messages from before subscribing, and check we get txMessageBeforeRxSubscribe
 
         /*
@@ -154,7 +237,7 @@ struct IntegrationTests {
 
          Revert this (https://github.com/ably/ably-chat-swift/issues/175) once it’s fixed in Realtime.
          */
-        let rxMessagesBeforeSubscribing = try await {
+        let rxMessagesHistory = try await {
             while true {
                 let messages = try await rxMessageSubscription.getPreviousMessages(params: .init())
                 if !messages.items.isEmpty {
@@ -164,8 +247,21 @@ struct IntegrationTests {
                 try await Task.sleep(nanoseconds: NSEC_PER_SEC)
             }
         }()
-        try #require(rxMessagesBeforeSubscribing.items.count == 1)
-        #expect(rxMessagesBeforeSubscribing.items[0] == txMessageBeforeRxSubscribe)
+        try #require(rxMessagesHistory.items.count == 1)
+
+        let rxMessageFromHistory = rxMessagesHistory.items[0]
+        #expect(rxMessageFromHistory.serial == txMessageBeforeRxSubscribe.serial) // rxMessageFromHistory contains reactions and txMessageBeforeRxSubscribe doesn't, so we only compare serials
+
+        let rxMessageFromHistoryReactions = try #require(rxMessageFromHistory.reactions)
+        #expect(rxMessageFromHistoryReactions.messageSerial == messageToReact.serial)
+        #expect(rxMessageFromHistoryReactions.unique.isEmpty)
+        #expect(rxMessageFromHistoryReactions.multiple.isEmpty)
+        #expect(rxMessageFromHistoryReactions.distinct.count == 1)
+        _ = rxMessageFromHistoryReactions.distinct.map { key, value in
+            #expect(key == "🔥")
+            #expect(value.total == 1)
+            #expect(value.clientIds == [messageToReact.clientID])
+        }
 
         // MARK: - Editing and Deleting Messages
 
@@ -224,7 +320,7 @@ struct IntegrationTests {
         #expect(rxDeletedMessageFromSubscription.headers == txDeleteMessage.headers)
         #expect(rxDeletedMessageFromSubscription.metadata == txDeleteMessage.metadata)
 
-        // MARK: - Reactions
+        // MARK: - Room Reactions
 
         // (1) Subscribe to reactions
         let rxReactionSubscription = rxRoom.reactions.subscribe()

--- a/Tests/AblyChatTests/Mocks/MockRealtime.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtime.swift
@@ -38,7 +38,13 @@ final class MockRealtime: InternalRealtimeClientProtocol {
         do {
             callRecorder.addRecord(
                 signature: "request(_:path:params:body:headers:)",
-                arguments: ["method": method, "path": path, "params": params, "body": body == nil ? [:] : body as? [String: Any], "headers": headers]
+                arguments: [
+                    "method": method,
+                    "path": path,
+                    "params": params ?? [:],
+                    "body": body == nil ? [:] : body as? [String: Any],
+                    "headers": headers ?? [:],
+                ]
             )
             return try paginatedCallback()
         } catch {

--- a/Tests/AblyChatTests/Mocks/MockRealtimeAnnotations.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeAnnotations.swift
@@ -1,0 +1,25 @@
+import Ably
+@testable import AblyChat
+
+final class MockRealtimeAnnotations: InternalRealtimeAnnotationsProtocol {
+    let annotationToEmitOnSubscribe: ARTAnnotation?
+
+    init(annotationToEmitOnSubscribe: ARTAnnotation? = nil) {
+        self.annotationToEmitOnSubscribe = annotationToEmitOnSubscribe
+    }
+
+    func subscribe(_ callback: @escaping @MainActor @Sendable (ARTAnnotation) -> Void) -> ARTEventListener? {
+        subscribe("all", callback: callback) // "all" is arbitrary here, could be "". Due to `name` is not optional.
+    }
+
+    func subscribe(_: String, callback: @escaping @MainActor @Sendable (ARTAnnotation) -> Void) -> ARTEventListener? {
+        if let annotation = annotationToEmitOnSubscribe {
+            callback(annotation)
+        }
+        return ARTEventListener()
+    }
+
+    func unsubscribe(_: ARTEventListener) {
+        fatalError("Not implemented")
+    }
+}

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -3,6 +3,7 @@ import Ably
 
 final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
     let presence = MockRealtimePresence()
+    let annotations: MockRealtimeAnnotations
 
     private let attachSerial: String?
     private let channelSerial: String?
@@ -30,6 +31,7 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
         attachBehavior: AttachOrDetachBehavior? = nil,
         detachBehavior: AttachOrDetachBehavior? = nil,
         messageToEmitOnSubscribe: ARTMessage? = nil,
+        annotationToEmitOnSubscribe: ARTAnnotation? = nil,
         stateChangeToEmitForListener: ARTChannelStateChange? = nil
     ) {
         _name = name
@@ -41,6 +43,7 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
         attachSerial = properties.attachSerial
         channelSerial = properties.channelSerial
         self.stateChangeToEmitForListener = stateChangeToEmitForListener
+        annotations = MockRealtimeAnnotations(annotationToEmitOnSubscribe: annotationToEmitOnSubscribe)
     }
 
     var state: ARTRealtimeChannelState {
@@ -133,6 +136,10 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
 
     let messageToEmitOnSubscribe: ARTMessage?
     private var channelSubscriptions: [(String, (ARTMessage) -> Void)] = []
+
+    func subscribe(_ callback: @escaping @MainActor @Sendable (ARTMessage) -> Void) -> ARTEventListener? {
+        subscribe("all", callback: callback) // "all" is arbitrary here, could be "". Due to `name` is not optional.
+    }
 
     // Added the ability to emit a message whenever we want instead of just on subscribe... I didn't want to dig into what the messageToEmitOnSubscribe is too much so just if/else between the two.
     func subscribe(_ name: String, callback: @escaping @MainActor (ARTMessage) -> Void) -> ARTEventListener? {

--- a/Tests/AblyChatTests/Mocks/MockSuppliedRealtime.swift
+++ b/Tests/AblyChatTests/Mocks/MockSuppliedRealtime.swift
@@ -92,6 +92,7 @@ final class MockSuppliedRealtime: NSObject, SuppliedRealtimeClientProtocol, @unc
 
     final class Channel: RealtimeChannelProtocol {
         let presence = MockSuppliedRealtime.Presence()
+        let annotations = MockSuppliedRealtime.Annotations()
 
         var state: ARTRealtimeChannelState {
             fatalError("Not implemented")
@@ -332,6 +333,28 @@ final class MockSuppliedRealtime: NSObject, SuppliedRealtimeClientProtocol, @unc
         }
 
         func history(_: ARTRealtimeHistoryQuery?, callback _: @escaping ARTPaginatedPresenceCallback) throws {
+            fatalError("Not implemented")
+        }
+    }
+
+    final class Annotations: RealtimeAnnotationsProtocol {
+        func subscribe(_: @escaping ARTAnnotationCallback) -> ARTEventListener? {
+            fatalError("Not implemented")
+        }
+
+        func subscribe(_: String, callback _: @escaping ARTAnnotationCallback) -> ARTEventListener? {
+            fatalError("Not implemented")
+        }
+
+        func unsubscribe() {
+            fatalError("Not implemented")
+        }
+
+        func unsubscribe(_: ARTEventListener) {
+            fatalError("Not implemented")
+        }
+
+        func unsubscribe(_: String, listener _: ARTEventListener) {
             fatalError("Not implemented")
         }
     }


### PR DESCRIPTION
Closes https://github.com/ably/ably-chat-swift/issues/296

Tests hanging will be addressed in a different PR - https://github.com/ably/ably-chat-swift/issues/295

Core SDK PR - https://github.com/ably/ably-cocoa/pull/2066

https://github.com/user-attachments/assets/29045fd9-76c8-4cc3-889a-80db72be17bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced message reactions: users can now add, delete, and view reactions (such as emojis) on chat messages.
  - Added UI components for displaying and interacting with message reactions, including reaction pickers and summary views.
  - Enabled real-time updates for message reactions, reflecting changes instantly in the chat interface.
  - Added support for viewing detailed reaction summaries and managing individual reactions.

- **Improvements**
  - Enhanced chat message display to show the current user's ID and reaction information.
  - Improved handling and display of client IDs and message serials for better clarity.

- **Bug Fixes**
  - Standardized naming conventions for room identifiers throughout the app.

- **Tests**
  - Added comprehensive tests for message reaction features, including summary and raw reaction event handling.

- **Chores**
  - Updated dependencies to use the latest branch supporting message annotations and reactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->