### PR TITLE
[ECO-5360] Switch spec coverage back to using main branch of spec

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -53,7 +53,7 @@ jobs:
           xcode-version: 16.2
 
       - name: Spec coverage
-        run: swift run BuildTool spec-coverage --spec-commit-sha 2f88b1b
+        run: swift run BuildTool spec-coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Reverts ac80ecc, now that the single-channel and heartbeat typing indicators branches are merged.

Resolves #281.