### PR TITLE
Temporarily disable SPM tests run

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -92,7 +92,8 @@ jobs:
 
       # https://forums.swift.org/t/warnings-as-errors-for-libraries-frameworks/58393/2
       - run: swift build -Xswiftc -warnings-as-errors
-      - run: swift test -Xswiftc -warnings-as-errors
+      # Disabling testing temporarily due to intermittent hangs on CI (https://github.com/ably/ably-chat-swift/issues/295)
+      #- run: swift test -Xswiftc -warnings-as-errors
 
   build-release-configuration-spm:
     name: SPM, `release` configuration (Xcode ${{ matrix.tooling.xcodeVersion }})


### PR DESCRIPTION
Addresses #295 

This will allow to stop tests hanging on CI until a better solution will show up.

Related PR - https://github.com/ably/ably-chat-swift/pull/297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the minimum deployment target for iOS and tvOS to version 16.
  - Temporarily disabled a test step in the continuous integration workflow due to intermittent issues.
- **Tests**
  - Added a 2-minute time limit to all unit test suites.
  - Set a 10-minute time limit for the integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->