### PR TITLE
[ECO-5342] Refactor wrap Message in the Messages subscription in MessageEvent

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -253,9 +253,10 @@ struct ContentView: View {
     }
 
     func showMessages(room: Room) async throws {
-        let subscription = try await room.messages.subscribe { message in
-            switch message.action {
-            case .create:
+        let subscription = try await room.messages.subscribe { event in
+            let message = event.message
+            switch event.type {
+            case .created:
                 withAnimation {
                     listItems.insert(
                         .message(
@@ -267,7 +268,7 @@ struct ContentView: View {
                         at: 0
                     )
                 }
-            case .update, .delete:
+            case .updated, .deleted:
                 if let index = listItems.firstIndex(where: { $0.id == message.id }) {
                     listItems[index] = .message(
                         .init(

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -114,7 +114,7 @@ class MockMessages: Messages {
         reactions as! MockMessageReactions
     }
 
-    private let mockSubscriptions = MockMessageSubscriptionStorage<Message>()
+    private let mockSubscriptions = MockMessageSubscriptionStorage<ChatMessageEvent>()
 
     init(clientID: String, roomName: String) {
         self.clientID = clientID
@@ -122,7 +122,7 @@ class MockMessages: Messages {
         reactions = MockMessageReactions(clientID: clientID, roomName: roomName)
     }
 
-    func subscribe(_ callback: @escaping @MainActor (Message) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
+    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
         mockSubscriptions.create(
             randomElement: {
                 let message = Message(
@@ -141,7 +141,7 @@ class MockMessages: Messages {
                     self.mockReactions.messageSerials.append(message.serial)
                 }
                 self.mockReactions.clientIDs.insert(message.clientID)
-                return message
+                return ChatMessageEvent(message: message)
             },
             previousMessages: { _ in
                 MockMessagesPaginatedResult(clientID: self.clientID, roomName: self.roomName)
@@ -168,7 +168,7 @@ class MockMessages: Messages {
             timestamp: Date(),
             operation: nil
         )
-        mockSubscriptions.emit(message)
+        mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message
     }
 
@@ -185,7 +185,7 @@ class MockMessages: Messages {
             timestamp: Date(),
             operation: .init(clientID: clientID)
         )
-        mockSubscriptions.emit(message)
+        mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message
     }
 
@@ -202,7 +202,7 @@ class MockMessages: Messages {
             timestamp: Date(),
             operation: .init(clientID: clientID)
         )
-        mockSubscriptions.emit(message)
+        mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message
     }
 }

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -18,7 +18,7 @@ internal final class DefaultMessages: Messages {
         implementation = .init(channel: channel, chatAPI: chatAPI, roomName: roomName, clientID: clientID, logger: logger)
     }
 
-    internal func subscribe(_ callback: @escaping @MainActor (Message) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
+    internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
         try await implementation.subscribe(callback)
     }
 
@@ -66,7 +66,7 @@ internal final class DefaultMessages: Messages {
         }
 
         // (CHA-M4) Messages can be received via a subscription in realtime.
-        internal func subscribe(_ callback: @escaping @MainActor (Message) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
+        internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
             do {
                 logger.log(message: "Subscribing to messages", level: .debug)
 
@@ -138,7 +138,8 @@ internal final class DefaultMessages: Messages {
                             operation: message.operation?.toChatOperation()
                         )
 
-                        callback(message)
+                        let event = ChatMessageEvent(message: message)
+                        callback(event)
                     } catch {
                         // note: this replaces some existing code that also didn't handle any thrown error; I suspect not intentional, will leave whoever writes the tests for this class to see what's going on
                         // note: I'm adding this log line here, because it's better then nothing. TODO: proper handling
@@ -172,7 +173,7 @@ internal final class DefaultMessages: Messages {
             }
         }
 
-        // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the “REST API”#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
+        // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
         internal func get(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
             do {
                 return try await chatAPI.getMessages(roomName: roomName, params: options)

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -359,10 +359,11 @@ struct DefaultMessagesTests {
         // When the expectation are not met test crashes with "Fatal error: Internal inconsistency: No test reporter for test AblyChatTests.DefaultMessagesTests/subscriptionCanBeRegisteredToReceiveIncomingMessages()/DefaultMessagesTests.swift:326:6 and test case argumentIDs: Optional([])". I guess this could be avoided by using `withCheckedContinuation`, but it doesn't accept async functions in its closure body (await subscribe).
 
         // When
-        let subscriptionHandle = try await defaultMessages.subscribe { message in
+        let subscriptionHandle = try await defaultMessages.subscribe { event in
             // Then
-            #expect(message.headers == ["numberKey": .number(10), "stringKey": .string("hello")])
-            #expect(message.metadata == ["numberKey": .number(10), "stringKey": .string("hello")])
+            #expect(event.type == .created)
+            #expect(event.message.headers == ["numberKey": .number(10), "stringKey": .string("hello")])
+            #expect(event.message.metadata == ["numberKey": .number(10), "stringKey": .string("hello")])
         }
 
         // CHA-M4b
@@ -405,9 +406,10 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        _ = try await defaultMessages.subscribe { message in
+        _ = try await defaultMessages.subscribe { event in
             // Then
-            #expect(message.serial == "123")
+            #expect(event.type == .created)
+            #expect(event.message.serial == "123")
         }
 
         // will not be received and expectations above will not fail

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -117,8 +117,8 @@ struct IntegrationTests {
         )
 
         // (4) Wait for rxRoom to see the message we just sent
-        let throwawayRxMessage = try #require(await throwawayRxMessageSubscription.first { @Sendable _ in true })
-        #expect(throwawayRxMessage == txMessageBeforeRxSubscribe)
+        let throwawayRxEvent = try #require(await throwawayRxMessageSubscription.first { @Sendable _ in true })
+        #expect(throwawayRxEvent.message == txMessageBeforeRxSubscribe)
 
         // (5) Subscribe to messages
         let rxMessageSubscription = try await rxRoom.messages.subscribe()
@@ -131,8 +131,8 @@ struct IntegrationTests {
                 headers: ["someHeadersKey": 456, "someOtherHeadersKey": "bar"]
             )
         )
-        let rxMessageFromSubscription = try #require(await rxMessageSubscription.first { @Sendable _ in true })
-        #expect(rxMessageFromSubscription == txMessageAfterRxSubscribe)
+        let rxEventFromSubscription = try #require(await rxMessageSubscription.first { @Sendable _ in true })
+        #expect(rxEventFromSubscription.message == txMessageAfterRxSubscribe)
 
         // MARK: - Message Reactions (Summary)
 
@@ -281,8 +281,8 @@ struct IntegrationTests {
         )
 
         // (2) Check that we received the edited message on the subscription
-        let rxEditedMessageFromSubscription = try #require(await rxMessageEditDeleteSubscription.first { @Sendable _ in true })
-
+        let rxEditedEventFromSubscription = try #require(await rxMessageEditDeleteSubscription.first { @Sendable _ in true })
+        let rxEditedMessageFromSubscription = rxEditedEventFromSubscription.message
         // The createdAt varies by milliseconds so we can't compare the entire objects directly
         #expect(rxEditedMessageFromSubscription.serial == txEditedMessage.serial)
         #expect(rxEditedMessageFromSubscription.clientID == txEditedMessage.clientID)
@@ -306,8 +306,8 @@ struct IntegrationTests {
         )
 
         // (4) Check that we received the deleted message on the subscription
-        let rxDeletedMessageFromSubscription = try #require(await rxMessageEditDeleteSubscription.first { @Sendable _ in true })
-
+        let rxDeletedEventFromSubscription = try #require(await rxMessageEditDeleteSubscription.first { @Sendable _ in true })
+        let rxDeletedMessageFromSubscription = rxDeletedEventFromSubscription.message
         // The createdAt varies by milliseconds so we can't compare the entire objects directly
         #expect(rxDeletedMessageFromSubscription.serial == txDeleteMessage.serial)
         #expect(rxDeletedMessageFromSubscription.clientID == txDeleteMessage.clientID)

--- a/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
@@ -31,21 +31,18 @@ struct MessageSubscriptionAsyncSequenceTests {
 
     @Test
     func withMockAsyncSequence() async {
-        let subscription = MessageSubscriptionAsyncSequence(mockAsyncSequence: messages.async) { _ in fatalError("Not implemented") }
-
-        #expect(await Array(subscription.prefix(2)).map(\.text) == ["First", "Second"])
+        let events = messages.map { ChatMessageEvent(message: $0) }
+        let subscription = MessageSubscriptionAsyncSequence(mockAsyncSequence: events.async) { _ in fatalError("Not implemented") }
+        #expect(await Array(subscription.prefix(2)).map(\.message.text) == ["First", "Second"])
     }
 
     @Test
     func emit() async {
         let subscription = MessageSubscriptionAsyncSequence(bufferingPolicy: .unbounded) { _ in fatalError("Not implemented") }
-
         async let emittedElements = Array(subscription.prefix(2))
-
-        subscription.emit(messages[0])
-        subscription.emit(messages[1])
-
-        #expect(await emittedElements.map(\.text) == ["First", "Second"])
+        subscription.emit(ChatMessageEvent(message: messages[0]))
+        subscription.emit(ChatMessageEvent(message: messages[1]))
+        #expect(await emittedElements.map(\.message.text) == ["First", "Second"])
     }
 
     @Test


### PR DESCRIPTION
Refactor wrap Message in the Messages subscription in ChatMessageEvent

[ECO-5342]

[ECO-5342]: https://ably.atlassian.net/browse/ECO-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new event structure for message subscriptions, providing richer event information including event type (created, updated, deleted) alongside the message content.

* **Bug Fixes**
  * Updated all relevant interfaces, callbacks, and tests to ensure compatibility with the new event-based message subscription system.

* **Tests**
  * Revised and enhanced test cases to validate the new event structure and ensure correct event type and message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->