### PR TITLE
[ECO-5342] Refactor `PresenceEvent` 

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -63,7 +63,7 @@ struct ContentView: View {
             case let .message(item):
                 item.message.id
             case let .presence(item):
-                item.presence.timestamp.description
+                item.presence.member.updatedAt.description
             }
         }
     }

--- a/Example/AblyChatExample/MessageViews/PresenceMessageView.swift
+++ b/Example/AblyChatExample/MessageViews/PresenceMessageView.swift
@@ -22,8 +22,8 @@ struct PresenceMessageView: View {
     }
 
     func generatePresenceMessage() -> String {
-        let status = item.presence.data?.objectValue?["status"]?.stringValue
-        let clientPresenceChangeMessage = "\(item.presence.clientID) \(item.presence.action.displayedText)"
+        let status = item.presence.member.data?.objectValue?["status"]?.stringValue
+        let clientPresenceChangeMessage = "\(item.presence.member.clientID) \(item.presence.type)"
         let presenceMessage = status != nil ? "\(clientPresenceChangeMessage) with status: \(status!)" : clientPresenceChangeMessage
         return presenceMessage
     }

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -414,11 +414,15 @@ class MockPresence: Presence {
     private func createSubscription(callback: @escaping @MainActor (PresenceEvent) -> Void) -> SubscriptionProtocol {
         mockSubscriptions.create(
             randomElement: {
-                PresenceEvent(
-                    action: [.enter, .leave].randomElement()!,
+                let member = PresenceMember(
                     clientID: MockStrings.names.randomElement()!,
-                    timestamp: Date(),
-                    data: nil
+                    data: nil,
+                    extras: nil,
+                    updatedAt: Date()
+                )
+                return PresenceEvent(
+                    type: [.enter, .leave].randomElement()!,
+                    member: member
                 )
             },
             interval: 5,
@@ -431,7 +435,6 @@ class MockPresence: Presence {
             PresenceMember(
                 clientID: name,
                 data: nil,
-                action: .present,
                 extras: nil,
                 updatedAt: Date()
             )
@@ -443,7 +446,6 @@ class MockPresence: Presence {
             PresenceMember(
                 clientID: name,
                 data: nil,
-                action: .present,
                 extras: nil,
                 updatedAt: Date()
             )
@@ -463,12 +465,16 @@ class MockPresence: Presence {
     }
 
     private func enter(dataForEvent: PresenceData?) async throws(ARTErrorInfo) {
+        let member = PresenceMember(
+            clientID: clientID,
+            data: dataForEvent,
+            extras: nil,
+            updatedAt: Date()
+        )
         mockSubscriptions.emit(
             PresenceEvent(
-                action: .enter,
-                clientID: clientID,
-                timestamp: Date(),
-                data: dataForEvent
+                type: .enter,
+                member: member
             )
         )
     }
@@ -482,12 +488,16 @@ class MockPresence: Presence {
     }
 
     private func update(dataForEvent: PresenceData? = nil) async throws(ARTErrorInfo) {
+        let member = PresenceMember(
+            clientID: clientID,
+            data: dataForEvent,
+            extras: nil,
+            updatedAt: Date()
+        )
         mockSubscriptions.emit(
             PresenceEvent(
-                action: .update,
-                clientID: clientID,
-                timestamp: Date(),
-                data: dataForEvent
+                type: .update,
+                member: member
             )
         )
     }
@@ -501,12 +511,16 @@ class MockPresence: Presence {
     }
 
     func leave(dataForEvent: PresenceData? = nil) async throws(ARTErrorInfo) {
+        let member = PresenceMember(
+            clientID: clientID,
+            data: dataForEvent,
+            extras: nil,
+            updatedAt: Date()
+        )
         mockSubscriptions.emit(
             PresenceEvent(
-                action: .leave,
-                clientID: clientID,
-                timestamp: Date(),
-                data: dataForEvent
+                type: .leave,
+                member: member
             )
         )
     }

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -344,7 +344,6 @@ internal final class DefaultPresence: Presence {
                 let presenceMember = PresenceMember(
                     clientID: clientID,
                     data: presenceDataDTO.userCustomData,
-                    action: PresenceMember.Action(from: member.action),
                     extras: member.extras,
                     updatedAt: timestamp
                 )
@@ -370,11 +369,16 @@ internal final class DefaultPresence: Presence {
 
             let presenceDataDTO = try decodePresenceDataDTO(from: message.data)
 
-            let presenceEvent = PresenceEvent(
-                action: event,
+            let member = PresenceMember(
                 clientID: clientID,
-                timestamp: timestamp,
-                data: presenceDataDTO.userCustomData
+                data: presenceDataDTO.userCustomData,
+                extras: message.extras,
+                updatedAt: timestamp
+            )
+
+            let presenceEvent = PresenceEvent(
+                type: event,
+                member: member
             )
 
             logger.log(message: "Returning presence event: \(presenceEvent)", level: .debug)

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -192,37 +192,9 @@ public extension Presence {
  * Type for PresenceMember
  */
 public struct PresenceMember: Sendable {
-    public enum Action: Sendable {
-        case present
-        case enter
-        case leave
-        case update
-        case absent
-        case unknown
-
-        internal init(from action: ARTPresenceAction) {
-            switch action {
-            case .present:
-                self = .present
-            case .enter:
-                self = .enter
-            case .leave:
-                self = .leave
-            case .update:
-                self = .update
-            case .absent:
-                self = .absent
-            @unknown default:
-                self = .unknown
-                print("Unknown presence action encountered: \(action)")
-            }
-        }
-    }
-
-    public init(clientID: String, data: PresenceData?, action: PresenceMember.Action, extras: [String: JSONValue]?, updatedAt: Date) {
+    public init(clientID: String, data: PresenceData?, extras: [String: JSONValue]?, updatedAt: Date) {
         self.clientID = clientID
         self.data = data
-        self.action = action
         self.extras = extras
         self.updatedAt = updatedAt
     }
@@ -237,11 +209,6 @@ public struct PresenceMember: Sendable {
      * `nil` means that there is no presence data; this is different to a `JSONValue` of case `.null`
      */
     public var data: PresenceData?
-
-    /**
-     * The current state of the presence member.
-     */
-    public var action: Action
 
     /**
      * The extras associated with the presence member.
@@ -295,28 +262,16 @@ public struct PresenceEvent: Sendable {
     /**
      * The type of the presence event.
      */
-    public var action: PresenceEventType
+    public var type: PresenceEventType
 
     /**
-     * The clientId of the client that triggered the presence event.
+     * The member associated with the presence event.
      */
-    public var clientID: String
+    public var member: PresenceMember
 
-    /**
-     * The timestamp of the presence event.
-     */
-    public var timestamp: Date
-
-    /**
-     * The data associated with the presence event.
-     */
-    public var data: PresenceData?
-
-    public init(action: PresenceEventType, clientID: String, timestamp: Date, data: PresenceData?) {
-        self.action = action
-        self.clientID = clientID
-        self.timestamp = timestamp
-        self.data = data
+    public init(type: PresenceEventType, member: PresenceMember) {
+        self.type = type
+        self.member = member
     }
 }
 

--- a/Tests/AblyChatTests/DefaultPresenceTests.swift
+++ b/Tests/AblyChatTests/DefaultPresenceTests.swift
@@ -454,35 +454,35 @@ struct DefaultPresenceTests {
         let subscription = await defaultPresence.subscribe(events: .all) // CHA-PR7a and CHA-PR7b since `all` is just a selection of all events
 
         // When
-        subscription.emit(PresenceEvent(action: .present, clientID: "client1", timestamp: Date(), data: nil))
+        subscription.emit(PresenceEvent(type: .present, member: PresenceMember(clientID: "client1", data: nil, extras: nil, updatedAt: Date())))
 
         // Then
         let presentEvent = try #require(await subscription.first { _ in true })
-        #expect(presentEvent.action == .present)
-        #expect(presentEvent.clientID == "client1")
+        #expect(presentEvent.type == .present)
+        #expect(presentEvent.member.clientID == "client1")
 
         // When
-        subscription.emit(PresenceEvent(action: .enter, clientID: "client1", timestamp: Date(), data: nil))
+        subscription.emit(PresenceEvent(type: .enter, member: PresenceMember(clientID: "client1", data: nil, extras: nil, updatedAt: Date())))
 
         // Then
         let enterEvent = try #require(await subscription.first { _ in true })
-        #expect(enterEvent.action == .enter)
-        #expect(enterEvent.clientID == "client1")
+        #expect(enterEvent.type == .enter)
+        #expect(enterEvent.member.clientID == "client1")
 
         // When
-        subscription.emit(PresenceEvent(action: .update, clientID: "client1", timestamp: Date(), data: nil))
+        subscription.emit(PresenceEvent(type: .update, member: PresenceMember(clientID: "client1", data: nil, extras: nil, updatedAt: Date())))
 
         // Then
         let updateEvent = try #require(await subscription.first { _ in true })
-        #expect(updateEvent.action == .update)
-        #expect(updateEvent.clientID == "client1")
+        #expect(updateEvent.type == .update)
+        #expect(updateEvent.member.clientID == "client1")
 
         // When
-        subscription.emit(PresenceEvent(action: .leave, clientID: "client1", timestamp: Date(), data: nil))
+        subscription.emit(PresenceEvent(type: .leave, member: PresenceMember(clientID: "client1", data: nil, extras: nil, updatedAt: Date())))
 
         // Then
         let leaveEvent = try #require(await subscription.first { _ in true })
-        #expect(leaveEvent.action == .leave)
-        #expect(leaveEvent.clientID == "client1")
+        #expect(leaveEvent.type == .leave)
+        #expect(leaveEvent.member.clientID == "client1")
     }
 }

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -384,44 +384,43 @@ struct IntegrationTests {
         // (2) Send `.enter` presence event with custom data on the other client and check that we receive it on the subscription
         try await txRoom.presence.enter(data: ["randomData": "randomValue"])
         let rxPresenceEnterTxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
-        #expect(rxPresenceEnterTxEvent.action == .enter)
-        #expect(rxPresenceEnterTxEvent.data == ["randomData": "randomValue"])
+        #expect(rxPresenceEnterTxEvent.type == .enter)
+        #expect(rxPresenceEnterTxEvent.member.data == ["randomData": "randomValue"])
 
         // (3) Fetch rxClient's presence members and check that txClient is there
         let rxPresenceMembers = try await rxRoom.presence.get()
         #expect(rxPresenceMembers.count == 1)
-        #expect(rxPresenceMembers[0].action == .present)
         #expect(rxPresenceMembers[0].data == ["randomData": "randomValue"])
 
         // (4) Send `.update` presence event with custom data on the other client and check that we receive it on the subscription
         try await txRoom.presence.update(data: ["randomData": "randomValue"])
         let rxPresenceUpdateTxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
-        #expect(rxPresenceUpdateTxEvent.action == .update)
-        #expect(rxPresenceUpdateTxEvent.data == ["randomData": "randomValue"])
+        #expect(rxPresenceUpdateTxEvent.type == .update)
+        #expect(rxPresenceUpdateTxEvent.member.data == ["randomData": "randomValue"])
 
         // (5) Send `.leave` presence event with custom data on the other client and check that we receive it on the subscription
         try await txRoom.presence.leave(data: ["randomData": "randomValue"])
         let rxPresenceLeaveTxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
-        #expect(rxPresenceLeaveTxEvent.action == .leave)
-        #expect(rxPresenceLeaveTxEvent.data == ["randomData": "randomValue"])
+        #expect(rxPresenceLeaveTxEvent.type == .leave)
+        #expect(rxPresenceLeaveTxEvent.member.data == ["randomData": "randomValue"])
 
         // (6) Send `.enter` presence event with custom data on our client and check that we receive it on the subscription
         try await txRoom.presence.enter(data: ["randomData": "randomValue"])
         let rxPresenceEnterRxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
-        #expect(rxPresenceEnterRxEvent.action == .enter)
-        #expect(rxPresenceEnterRxEvent.data == ["randomData": "randomValue"])
+        #expect(rxPresenceEnterRxEvent.type == .enter)
+        #expect(rxPresenceEnterRxEvent.member.data == ["randomData": "randomValue"])
 
         // (7) Send `.update` presence event with custom data on our client and check that we receive it on the subscription
         try await txRoom.presence.update(data: ["randomData": "randomValue"])
         let rxPresenceUpdateRxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
-        #expect(rxPresenceUpdateRxEvent.action == .update)
-        #expect(rxPresenceUpdateRxEvent.data == ["randomData": "randomValue"])
+        #expect(rxPresenceUpdateRxEvent.type == .update)
+        #expect(rxPresenceUpdateRxEvent.member.data == ["randomData": "randomValue"])
 
         // (8) Send `.leave` presence event with custom data on our client and check that we receive it on the subscription
         try await txRoom.presence.leave(data: ["randomData": "randomValue"])
         let rxPresenceLeaveRxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
-        #expect(rxPresenceLeaveRxEvent.action == .leave)
-        #expect(rxPresenceLeaveRxEvent.data == ["randomData": "randomValue"])
+        #expect(rxPresenceLeaveRxEvent.type == .leave)
+        #expect(rxPresenceLeaveRxEvent.member.data == ["randomData": "randomValue"])
 
         // MARK: - Typing Indicators
 


### PR DESCRIPTION
Refactor `PresenceMember` and `PresenceEvent` to remove `action` property and simplify data structure

[ECO-5342]

[ECO-5342]: https://ably.atlassian.net/browse/ECO-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated presence event and member data structures for improved consistency and clarity across the app.
  * Consolidated presence event details into unified objects and streamlined property names.

* **Bug Fixes**
  * Adjusted presence status and identifier handling to ensure accurate display and tracking in the user interface.

* **Tests**
  * Updated and improved tests to align with the new presence event structure and property names.
  * Simplified test code for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->