### PR TITLE
[ECO-5286] Remove async and throwing from Messages.subscribe

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -253,7 +253,7 @@ struct ContentView: View {
     }
 
     func showMessages(room: Room) async throws {
-        let subscription = try await room.messages.subscribe { event in
+        let subscription = room.messages.subscribe { event in
             let message = event.message
             switch event.type {
             case .created:

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -122,7 +122,7 @@ class MockMessages: Messages {
         reactions = MockMessageReactions(clientID: clientID, roomName: roomName)
     }
 
-    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
+    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> MessageSubscriptionResponseProtocol {
         mockSubscriptions.create(
             randomElement: {
                 let message = Message(

--- a/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
@@ -57,10 +57,12 @@ internal protocol InternalRealtimeChannelProtocol: AnyObject, Sendable {
     func attach() async throws(InternalError)
     func detach() async throws(InternalError)
     var name: String { get }
-    var state: ARTRealtimeChannelState { get async }
-    var errorReason: ARTErrorInfo? { get async }
+    var state: ARTRealtimeChannelState { get }
+    var errorReason: ARTErrorInfo? { get }
     func on(_ cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener
     func on(_ event: ARTChannelEvent, callback cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener
+    func once(_ cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener
+    func once(_ event: ARTChannelEvent, callback cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener
     func unsubscribe(_: ARTEventListener?)
     func publish(_ name: String?, data: JSONValue?, extras: [String: JSONValue]?) async throws(InternalError)
     func subscribe(_ callback: @escaping @MainActor (ARTMessage) -> Void) -> ARTEventListener?
@@ -264,6 +266,14 @@ internal final class InternalRealtimeClientAdapter: InternalRealtimeClientProtoc
 
         internal func on(_ event: ARTChannelEvent, callback cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener {
             underlying.on(event, callback: toAblyCocoaCallback(cb))
+        }
+
+        internal func once(_ cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener {
+            underlying.once(toAblyCocoaCallback(cb))
+        }
+
+        internal func once(_ event: ARTChannelEvent, callback cb: @escaping @MainActor (ARTChannelStateChange) -> Void) -> ARTEventListener {
+            underlying.once(event, callback: toAblyCocoaCallback(cb))
         }
 
         internal func unsubscribe(_ listener: ARTEventListener?) {

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -1,11 +1,5 @@
 import Ably
 
-// Wraps the MessageSubscription with the message serial of when the subscription was attached or resumed.
-private struct MessageSubscriptionWrapper {
-    let subscription: MessageSubscriptionResponse
-    var serial: String
-}
-
 internal final class DefaultMessages: Messages {
     internal let reactions: any MessageReactions
 
@@ -18,8 +12,8 @@ internal final class DefaultMessages: Messages {
         implementation = .init(channel: channel, chatAPI: chatAPI, roomName: roomName, clientID: clientID, logger: logger)
     }
 
-    internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
-        try await implementation.subscribe(callback)
+    internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> MessageSubscriptionResponseProtocol {
+        implementation.subscribe(callback)
     }
 
     internal func history(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
@@ -51,8 +45,24 @@ internal final class DefaultMessages: Messages {
         private let clientID: String
         private let logger: InternalLogger
 
-        // UUID acts as a unique identifier for each listener/subscription. MessageSubscriptionWrapper houses the subscription and the serial of when it was attached or resumed.
-        private var subscriptionPoints: [UUID: MessageSubscriptionWrapper] = [:]
+        // Continuously updated channel's attach serial to pickup by a new subscription or a history call.
+        private var currentSubscriptionPoint: String?
+
+        // Keeps subscription start point to retrive upon user's history request. Defaults to currentSubscriptionPoint above.
+        private var subscriptionPoints: [UUID: String] = [:]
+
+        private func updateCurrentSubscriptionPoint() {
+            currentSubscriptionPoint = channel.properties.attachSerial
+            _ = channel.on { [weak self] stateChange in
+                guard let self else {
+                    return
+                }
+                if stateChange.current == .attached, !stateChange.resumed {
+                    currentSubscriptionPoint = channel.properties.attachSerial
+                    subscriptionPoints.removeAll()
+                }
+            }
+        }
 
         internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, clientID: String, logger: InternalLogger) {
             self.channel = channel
@@ -60,117 +70,113 @@ internal final class DefaultMessages: Messages {
             self.roomName = roomName
             self.clientID = clientID
             self.logger = logger
-
-            // Implicitly handles channel events and therefore listners within this class. Alternative is to explicitly call something like `DefaultMessages.start()` which makes the SDK more cumbersome to interact with. This class is useless without kicking off this flow so I think leaving it here is suitable.
-            handleChannelEvents(roomName: roomName)
+            updateCurrentSubscriptionPoint()
         }
 
         // (CHA-M4) Messages can be received via a subscription in realtime.
-        internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol {
-            do {
-                logger.log(message: "Subscribing to messages", level: .debug)
-
-                // (CHA-M4c) When a realtime message with name set to message.created is received, it is translated into a message event, which contains a type field with the event type as well as a message field containing the Message Struct. This event is then broadcast to all subscribers.
-                // (CHA-M4d) If a realtime message with an unknown name is received, the SDK shall silently discard the message, though it may log at DEBUG or TRACE level.
-                // (CHA-M5k) Incoming realtime events that are malformed (unknown field should be ignored) shall not be emitted to subscribers.
-                let eventListener = channel.subscribe(RealtimeMessageName.chatMessage.rawValue) { [logger] message in
-                    do {
-                        guard let action = MessageAction.fromRealtimeAction(message.action) else {
-                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message with unsupported action: \(message.action)") // CHA-M4k11
-                        }
-
-                        // TODO: Revisit errors thrown as part of https://github.com/ably-labs/ably-chat-swift/issues/32
-                        guard let ablyCocoaData = message.data,
-                              let data = JSONValue(ablyCocoaData: ablyCocoaData).objectValue,
-                              let text = action == .delete /* CHA-M4m5 */ ? "" : data["text"]?.stringValue
-                        else {
-                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without data or text") // CHA-M4k1, CHA-M4k4
-                        }
-
-                        guard let serial = message.serial else {
-                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without serial") // CHA-M4k7
-                        }
-
-                        guard let clientID = message.clientId else {
-                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without clientId") // CHA-M4k2
-                        }
-
-                        guard let version = message.version else {
-                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without version") // CHA-M4k8
-                        }
-
-                        let metadata: Metadata?
-                        let headers: Headers?
-
-                        if action == .delete {
-                            metadata = [:] // CHA-M4m6
-                            headers = [:] // CHA-M4m7
-                        } else {
-                            metadata = try data.optionalObjectValueForKey("metadata")
-                            guard metadata != nil else {
-                                throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without metadata") // CHA-M4k6
-                            }
-
-                            guard let ablyCocoaExtras = message.extras else {
-                                throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without extras")
-                            }
-
-                            let extras = JSONValue.objectFromAblyCocoaExtras(ablyCocoaExtras)
-
-                            headers = if let headersJSONObject = try extras.optionalObjectValueForKey("headers") {
-                                try headersJSONObject.mapValues { try HeadersValue(jsonValue: $0) }
-                            } else {
-                                throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without headers") // CHA-M4k5
-                            }
-                        }
-
-                        // `message.operation?.toChatOperation()` is throwing but the linter prefers putting the `try` on Message initialization instead of having it nested.
-                        let message = try Message(
-                            serial: serial,
-                            action: action,
-                            clientID: clientID,
-                            text: text,
-                            createdAt: message.timestamp,
-                            metadata: metadata ?? .init(),
-                            headers: headers ?? .init(),
-                            version: version,
-                            timestamp: message.timestamp,
-                            operation: message.operation?.toChatOperation()
-                        )
-
-                        let event = ChatMessageEvent(message: message)
-                        callback(event)
-                    } catch {
-                        // note: this replaces some existing code that also didn't handle any thrown error; I suspect not intentional, will leave whoever writes the tests for this class to see what's going on
-                        // note: I'm adding this log line here, because it's better then nothing. TODO: proper handling
-                        logger.log(message: "Realtime message receive error: \(error)", level: .error)
+        internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> MessageSubscriptionResponseProtocol {
+            logger.log(message: "Subscribing to messages", level: .debug)
+            // (CHA-M4c) When a realtime message with name set to message.created is received, it is translated into a message event, which contains a type field with the event type as well as a message field containing the Message Struct. This event is then broadcast to all subscribers.
+            // (CHA-M4d) If a realtime message with an unknown name is received, the SDK shall silently discard the message, though it may log at DEBUG or TRACE level.
+            // (CHA-M5k) Incoming realtime events that are malformed (unknown field should be ignored) shall not be emitted to subscribers.
+            let eventListener = channel.subscribe(RealtimeMessageName.chatMessage.rawValue) { [logger] message in
+                do {
+                    guard let action = MessageAction.fromRealtimeAction(message.action) else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message with unsupported action: \(message.action)") // CHA-M4k11
                     }
+
+                    // TODO: Revisit errors thrown as part of https://github.com/ably-labs/ably-chat-swift/issues/32
+                    guard let ablyCocoaData = message.data,
+                          let data = JSONValue(ablyCocoaData: ablyCocoaData).objectValue,
+                          let text = action == .delete /* CHA-M4m5 */ ? "" : data["text"]?.stringValue
+                    else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without data or text") // CHA-M4k1, CHA-M4k4
+                    }
+
+                    guard let serial = message.serial else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without serial") // CHA-M4k7
+                    }
+
+                    guard let clientID = message.clientId else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without clientId") // CHA-M4k2
+                    }
+
+                    guard let version = message.version else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without version") // CHA-M4k8
+                    }
+
+                    let metadata: Metadata?
+                    let headers: Headers?
+
+                    if action == .delete {
+                        metadata = [:] // CHA-M4m6
+                        headers = [:] // CHA-M4m7
+                    } else {
+                        metadata = try data.optionalObjectValueForKey("metadata")
+                        guard metadata != nil else {
+                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without metadata") // CHA-M4k6
+                        }
+
+                        guard let ablyCocoaExtras = message.extras else {
+                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without extras")
+                        }
+
+                        let extras = JSONValue.objectFromAblyCocoaExtras(ablyCocoaExtras)
+
+                        headers = if let headersJSONObject = try extras.optionalObjectValueForKey("headers") {
+                            try headersJSONObject.mapValues { try HeadersValue(jsonValue: $0) }
+                        } else {
+                            throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without headers") // CHA-M4k5
+                        }
+                    }
+
+                    // `message.operation?.toChatOperation()` is throwing but the linter prefers putting the `try` on Message initialization instead of having it nested.
+                    let message = try Message(
+                        serial: serial,
+                        action: action,
+                        clientID: clientID,
+                        text: text,
+                        createdAt: message.timestamp,
+                        metadata: metadata ?? .init(),
+                        headers: headers ?? .init(),
+                        version: version,
+                        timestamp: message.timestamp,
+                        operation: message.operation?.toChatOperation()
+                    )
+
+                    let event = ChatMessageEvent(message: message)
+                    callback(event)
+                } catch {
+                    // note: this replaces some existing code that also didn't handle any thrown error; I suspect not intentional, will leave whoever writes the tests for this class to see what's going on
+                    // note: I'm adding this log line here, because it's better then nothing. TODO: proper handling
+                    logger.log(message: "Realtime message receive error: \(error)", level: .error)
                 }
-
-                let uuid = UUID()
-                let serial = try await resolveSubscriptionStart()
-
-                // coderabbitai suggestion (remove "guard let self" and hold ref to channel):
-                // > If DefaultMessages is deallocated before the client calls unsubscribe(), the listener remains registered because the closure early-returns. Store the eventListener and always call channel.unsubscribe regardless of self
-                let messageSubscriptionResponse = MessageSubscriptionResponse { [weak self, channel] in
+            }
+            let uuid = UUID()
+            // (CHA-M5a) If a subscription is added when the underlying realtime channel is ATTACHED, then the subscription point is the current channelSerial of the realtime channel.
+            if channel.state == .attached {
+                subscriptionPoints[uuid] = channel.properties.channelSerial
+            }
+            let subscription = MessageSubscriptionResponse(
+                chatAPI: chatAPI,
+                roomName: roomName,
+                subscriptionStartSerial: { [weak self] () throws(InternalError) in
+                    guard let self else {
+                        throw MessagesError.noReferenceToSelf.toInternalError()
+                    }
+                    if channel.state == .attached, let startSerial = subscriptionPoints[uuid] {
+                        return startSerial
+                    }
+                    let startSerial = try await resolveSubscriptionStart()
+                    subscriptionPoints[uuid] = startSerial
+                    return startSerial
+                },
+                unsubscribe: { [weak self, channel] in
                     channel.unsubscribe(eventListener)
                     self?.subscriptionPoints.removeValue(forKey: uuid)
-                } historyBeforeSubscribe: { [weak self] queryOptions throws(ARTErrorInfo) in
-                    guard let self else { throw MessagesError.noReferenceToSelf.toInternalError().toARTErrorInfo() }
-                    do throws(InternalError) {
-                        return try await getBeforeSubscriptionStart(uuid, params: queryOptions)
-                    } catch {
-                        throw error.toARTErrorInfo()
-                    }
                 }
-
-                // (CHA-M4a) A subscription can be registered to receive incoming messages. Adding a subscription has no side effects on the status of the room or the underlying realtime channel.
-                subscriptionPoints[uuid] = .init(subscription: messageSubscriptionResponse, serial: serial)
-
-                return messageSubscriptionResponse
-            } catch {
-                throw error.toARTErrorInfo()
-            }
+            )
+            return subscription
         }
 
         // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
@@ -206,130 +212,36 @@ internal final class DefaultMessages: Messages {
             }
         }
 
-        private func getBeforeSubscriptionStart(_ uuid: UUID, params: QueryOptions) async throws(InternalError) -> any PaginatedResult<Message> {
-            guard let subscriptionPoint = subscriptionPoints[uuid]?.serial else {
-                throw ARTErrorInfo.create(
-                    withCode: 40000,
-                    status: 400,
-                    message: "cannot query history; listener has not been subscribed yet"
-                )
-                .toInternalError()
-            }
-
-            // (CHA-M5f) This method must accept any of the standard history query options, except for direction, which must always be backwards.
-            var queryOptions = params
-            queryOptions.orderBy = .newestFirst // newestFirst is equivalent to backwards
-
-            // (CHA-M5g) The subscribers subscription point must be additionally specified (internally, by us) in the fromSerial query parameter.
-            queryOptions.fromSerial = subscriptionPoint
-
-            return try await chatAPI.getMessages(roomName: roomName, params: queryOptions)
-        }
-
-        private func handleChannelEvents(roomName _: String) {
-            // (CHA-M5c) If a channel leaves the ATTACHED state and then re-enters ATTACHED with resumed=false, then it must be assumed that messages have been missed. The subscription point of any subscribers must be reset to the attachSerial.
-            _ = channel.on(.attached) { [weak self] stateChange in
-                Task {
-                    do {
-                        try await self?.handleAttach(fromResume: stateChange.resumed)
-                    } catch {
-                        throw ARTErrorInfo.create(from: error)
-                    }
-                }
-            }
-
-            // (CHA-M4d) If a channel UPDATE event is received and resumed=false, then it must be assumed that messages have been missed. The subscription point of any subscribers must be reset to the attachSerial.
-            _ = channel.on(.update) { [weak self] stateChange in
-                Task {
-                    do {
-                        try await self?.handleAttach(fromResume: stateChange.resumed)
-                    } catch {
-                        throw ARTErrorInfo.create(from: error)
-                    }
-                }
-            }
-        }
-
-        private func handleAttach(fromResume: Bool) async throws {
-            logger.log(message: "Handling attach", level: .debug)
-            // Do nothing if we have resumed as there is no discontinuity in the message stream
-            if fromResume {
-                logger.log(message: "Channel has resumed, no need to handle attach", level: .debug)
-                return
-            }
-
-            do {
-                let serialOnChannelAttach = try await serialOnChannelAttach()
-
-                for uuid in subscriptionPoints.keys {
-                    logger.log(message: "Resetting subscription point for listener: \(uuid)", level: .debug)
-                    subscriptionPoints[uuid]?.serial = serialOnChannelAttach
-                }
-            } catch {
-                logger.log(message: "Error handling attach: \(error)", level: .error)
-                throw ARTErrorInfo.create(from: error)
-            }
-        }
-
         private func resolveSubscriptionStart() async throws(InternalError) -> String {
-            logger.log(message: "Resolving subscription start", level: .debug)
+            logger.log(message: "Resolving subscription start serial", level: .debug)
             // (CHA-M5a) If a subscription is added when the underlying realtime channel is ATTACHED, then the subscription point is the current channelSerial of the realtime channel.
-            if await channel.state == .attached {
-                if let channelSerial = channel.properties.channelSerial {
-                    logger.log(message: "Channel is attached, returning channelSerial: \(channelSerial)", level: .debug)
-                    return channelSerial
-                } else {
-                    let error = ARTErrorInfo.create(withCode: 40000, status: 400, message: "channel is attached, but channelSerial is not defined")
-                    logger.log(message: "Error resolving subscription start: \(error)", level: .error)
-                    throw error.toInternalError()
-                }
-            }
-
-            // (CHA-M5b) If a subscription is added when the underlying realtime channel is in any other state, then its subscription point becomes the attachSerial at the the point of channel attachment.
-            return try await serialOnChannelAttach()
-        }
-
-        // Always returns the attachSerial and not the channelSerial to also serve (CHA-M5c) - If a channel leaves the ATTACHED state and then re-enters ATTACHED with resumed=false, then it must be assumed that messages have been missed. The subscription point of any subscribers must be reset to the attachSerial.
-        private func serialOnChannelAttach() async throws(InternalError) -> String {
-            logger.log(message: "Resolving serial on channel attach", level: .debug)
-            // If the state is already 'attached', return the attachSerial immediately
-            if await channel.state == .attached {
-                if let attachSerial = channel.properties.attachSerial {
-                    logger.log(message: "Channel is attached, returning attachSerial: \(attachSerial)", level: .debug)
-                    return attachSerial
-                } else {
-                    let error = ARTErrorInfo.create(withCode: 40000, status: 400, message: "Channel is attached, but attachSerial is not defined")
-                    logger.log(message: "Error resolving serial on channel attach: \(error)", level: .error)
-                    throw error.toInternalError()
-                }
+            if channel.state == .attached, let currentSubscriptionPoint {
+                logger.log(message: "Channel is attached, returning subscription point serial: \(currentSubscriptionPoint)", level: .debug)
+                return currentSubscriptionPoint
             }
 
             // (CHA-M5b) If a subscription is added when the underlying realtime channel is in any other state, then its subscription point becomes the attachSerial at the the point of channel attachment.
             return try await withCheckedContinuation { (continuation: CheckedContinuation<Result<String, InternalError>, Never>) in
-                // avoids multiple invocations of the continuation
-                var nillableContinuation: CheckedContinuation<Result<String, InternalError>, Never>? = continuation
-
-                _ = channel.on { [weak self] stateChange in
+                _ = channel.once { [weak self] stateChange in
                     guard let self else {
                         return
                     }
-
                     switch stateChange.current {
                     case .attached:
-                        // Handle successful attachment
-                        if let attachSerial = channel.properties.attachSerial {
-                            logger.log(message: "Channel is attached, returning attachSerial: \(attachSerial)", level: .debug)
-                            nillableContinuation?.resume(returning: .success(attachSerial))
+                        // CHA-M5c If a channel leaves the ATTACHED state and then re-enters ATTACHED with resumed=false, then it must be assumed that messages have been missed. The subscription point of any subscribers must be reset to the attachSerial
+                        // CHA-M5d If a channel UPDATE event is received and resumed=false, then it must be assumed that messages have been missed. The subscription point of any subscribers must be reset to the attachSerial
+                        if let subscriptionPoint = stateChange.resumed ? channel.properties.channelSerial : channel.properties.attachSerial {
+                            logger.log(message: "Channel is attached, returning serial: \(subscriptionPoint)", level: .debug)
+                            continuation.resume(returning: .success(subscriptionPoint))
                         } else {
                             logger.log(message: "Channel is attached, but attachSerial is not defined", level: .error)
-                            nillableContinuation?.resume(returning: .failure(ARTErrorInfo.create(withCode: 40000, status: 400, message: "Channel is attached, but attachSerial is not defined").toInternalError()))
+                            continuation.resume(returning: .failure(ARTErrorInfo.create(withCode: 40000, status: 400, message: "Channel is attached, but attachSerial is not defined").toInternalError()))
                         }
-                        nillableContinuation = nil
                     case .failed, .suspended:
                         // TODO: Revisit as part of https://github.com/ably-labs/ably-chat-swift/issues/32
                         logger.log(message: "Channel failed to attach", level: .error)
                         let errorCodeCase = ErrorCode.CaseThatImpliesFixedStatusCode.badRequest
-                        nillableContinuation?.resume(
+                        continuation.resume(
                             returning: .failure(
                                 ARTErrorInfo.create(
                                     withCode: errorCodeCase.toNumericErrorCode.rawValue,
@@ -339,7 +251,6 @@ internal final class DefaultMessages: Messages {
                                 .toInternalError()
                             )
                         )
-                        nillableContinuation = nil
                     default:
                         break
                     }

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -16,7 +16,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: A subscription that can be used to unsubscribe from `ChatMessageEvent` events.
      */
-    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) async throws(ARTErrorInfo) -> MessageSubscriptionResponseProtocol
+    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> MessageSubscriptionResponseProtocol
 
     /**
      * Get messages that have been previously sent to the chat room, based on the provided options.
@@ -88,9 +88,9 @@ public extension Messages {
      *
      * - Returns: A subscription ``MessageSubscription`` that can be used to iterate through new messages.
      */
-    func subscribe(bufferingPolicy: BufferingPolicy) async throws(ARTErrorInfo) -> MessageSubscriptionAsyncSequence {
+    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscriptionAsyncSequence {
         var emitEvent: ((ChatMessageEvent) -> Void)?
-        let subscription = try await subscribe { event in
+        let subscription = subscribe { event in
             emitEvent?(event)
         }
 
@@ -112,8 +112,8 @@ public extension Messages {
     }
 
     /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
-    func subscribe() async throws(ARTErrorInfo) -> MessageSubscriptionAsyncSequence {
-        try await subscribe(bufferingPolicy: .unbounded)
+    func subscribe() -> MessageSubscriptionAsyncSequence {
+        subscribe(bufferingPolicy: .unbounded)
     }
 }
 

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -418,7 +418,7 @@ internal class DefaultRoomLifecycleManager: RoomLifecycleManager {
             try await channel.attach()
         } catch {
             // CHA-RL1k2, CHA-RL1k3
-            let channelState = await channel.state
+            let channelState = channel.state
             logger.log(message: "Failed to attach channel, error \(error), channel now in \(channelState)", level: .info)
             changeStatus(to: .init(channelState: channelState, error: error.toARTErrorInfo()))
             throw error
@@ -484,7 +484,7 @@ internal class DefaultRoomLifecycleManager: RoomLifecycleManager {
             try await channel.detach()
         } catch {
             // CHA-RL2k2, CHA-RL2k3
-            let channelState = await channel.state
+            let channelState = channel.state
             logger.log(message: "Failed to detach channel, error \(error), channel now in \(channelState)", level: .info)
             changeStatus(to: .init(channelState: channelState, error: error.toARTErrorInfo()))
             throw error
@@ -547,7 +547,7 @@ internal class DefaultRoomLifecycleManager: RoomLifecycleManager {
         // CHA-RL3n
         while true {
             // CHA-RL3n1
-            if await channel.state == .failed {
+            if channel.state == .failed {
                 logger.log(message: "Channel is FAILED; skipping detach", level: .info)
                 break
             }
@@ -559,7 +559,7 @@ internal class DefaultRoomLifecycleManager: RoomLifecycleManager {
                 break
             } catch {
                 // CHA-RL3n3
-                if await channel.state == .failed {
+                if channel.state == .failed {
                     logger.log(message: "Channel is FAILED after detach; exiting detach loop", level: .info)
                     break
                 }

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -67,7 +67,7 @@ struct DefaultMessagesTests {
             initialState: .attached
         )
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
-        let subscription = try await defaultMessages.subscribe()
+        let subscription = defaultMessages.subscribe()
         _ = try await subscription.getPreviousMessages(params: .init())
 
         // Then: subscription point is the current channelSerial of the realtime channel
@@ -85,7 +85,7 @@ struct DefaultMessagesTests {
         let realtime = MockRealtime {
             MockHTTPPaginatedResponse.successSendMessageWithNoItems
         }
-        let attachSerial = "123"
+        let attachSerial = "attach123"
         let chatAPI = ChatAPI(realtime: realtime)
         let channel = MockRealtimeChannel(
             properties: ARTChannelProperties(attachSerial: attachSerial, channelSerial: nil),
@@ -95,7 +95,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When: subscription is added when the underlying realtime channel is ATTACHING
-        let subscription = try await defaultMessages.subscribe()
+        let subscription = defaultMessages.subscribe()
         _ = try await subscription.getPreviousMessages(params: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
@@ -122,8 +122,8 @@ struct DefaultMessagesTests {
         )
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
-        // When: subscription is added when the underlying realtime channel is ATTACHING
-        let subscription = try await defaultMessages.subscribe()
+        // When: subscription is added when the underlying realtime channel is ATTACHED
+        let subscription = defaultMessages.subscribe()
         _ = try await subscription.getPreviousMessages(params: .init())
 
         #expect(realtime.callRecorder.hasRecord(
@@ -166,8 +166,8 @@ struct DefaultMessagesTests {
         )
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
-        // When: subscription is added when the underlying realtime channel is ATTACHING
-        let subscription = try await defaultMessages.subscribe()
+        // When: subscription is added when the underlying realtime channel is ATTACHED
+        let subscription = defaultMessages.subscribe()
         _ = try await subscription.getPreviousMessages(params: .init())
 
         #expect(realtime.callRecorder.hasRecord(
@@ -176,6 +176,7 @@ struct DefaultMessagesTests {
         )
         )
 
+        // When: UPDATE event received
         channel.emitEvent(
             ARTChannelStateChange(current: .attached, previous: .attached, event: .update, reason: nil, resumed: false)
         )
@@ -208,7 +209,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
-        let subscription = try await defaultMessages.subscribe()
+        let subscription = defaultMessages.subscribe()
         let paginatedResult = try await subscription.getPreviousMessages(params: .init(orderBy: .oldestFirst)) // CHA-M5f, try to set unsupported direction
 
         let requestParams = try #require(realtime.requestArguments.first?.params)
@@ -246,7 +247,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        let subscription = try await defaultMessages.subscribe()
+        let subscription = defaultMessages.subscribe()
 
         // Then
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
@@ -359,7 +360,7 @@ struct DefaultMessagesTests {
         // When the expectation are not met test crashes with "Fatal error: Internal inconsistency: No test reporter for test AblyChatTests.DefaultMessagesTests/subscriptionCanBeRegisteredToReceiveIncomingMessages()/DefaultMessagesTests.swift:326:6 and test case argumentIDs: Optional([])". I guess this could be avoided by using `withCheckedContinuation`, but it doesn't accept async functions in its closure body (await subscribe).
 
         // When
-        let subscriptionHandle = try await defaultMessages.subscribe { event in
+        let subscriptionHandle = defaultMessages.subscribe { event in
             // Then
             #expect(event.type == .created)
             #expect(event.message.headers == ["numberKey": .number(10), "stringKey": .string("hello")])
@@ -406,7 +407,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        _ = try await defaultMessages.subscribe { event in
+        _ = defaultMessages.subscribe { event in
             // Then
             #expect(event.type == .created)
             #expect(event.message.serial == "123")

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -107,7 +107,7 @@ struct IntegrationTests {
         // (1) Send a message before subscribing to messages, so that later on we can check history works.
 
         // (2) Create a throwaway subscription and wait for it to receive a message. This is to make sure that rxRoom has seen the message that we send here, so that the first message we receive on the subscription created in (5) is that which we'll send in (6), and not that which we send here.
-        let throwawayRxMessageSubscription = try await rxRoom.messages.subscribe()
+        let throwawayRxMessageSubscription = rxRoom.messages.subscribe()
 
         // (3) Send the message
         let txMessageBeforeRxSubscribe = try await txRoom.messages.send(
@@ -121,7 +121,7 @@ struct IntegrationTests {
         #expect(throwawayRxEvent.message == txMessageBeforeRxSubscribe)
 
         // (5) Subscribe to messages
-        let rxMessageSubscription = try await rxRoom.messages.subscribe()
+        let rxMessageSubscription = rxRoom.messages.subscribe()
 
         // (6) Now that we're subscribed to messages, send a message on the other client and check that we receive it on the subscription
         let txMessageAfterRxSubscribe = try await txRoom.messages.send(

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -176,6 +176,18 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
         return ARTEventListener()
     }
 
+    func once(_ callback: @escaping @MainActor @Sendable (ARTChannelStateChange) -> Void) -> ARTEventListener {
+        stateSubscriptionCallbacks.append(callback)
+        if let stateChangeToEmitForListener {
+            callback(stateChangeToEmitForListener)
+        }
+        return ARTEventListener()
+    }
+
+    func once(_: ARTChannelEvent, callback _: @escaping @MainActor @Sendable (ARTChannelStateChange) -> Void) -> ARTEventListener {
+        fatalError("Not implemented")
+    }
+
     func emitEvent(_ event: ARTChannelStateChange) {
         for callback in stateSubscriptionCallbacks {
             callback(event)


### PR DESCRIPTION
Closes #257 and #225

`Messages.subscribe()` is not async or throws anymore. Also fixes for `Messages.subscribe()` doesn't return until channel becomes attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new methods for listening to channel state changes, improving channel event handling capabilities.

* **Refactor**
  * Simplified and centralized message subscription point management for improved reliability.
  * Changed message subscription methods to be synchronous and non-throwing, streamlining their usage.
  * Updated subscription types and visibility for better encapsulation and internal consistency.

* **Bug Fixes**
  * Improved error logging and validation during message processing.

* **Tests**
  * Updated tests to match new synchronous subscription APIs and validate subscription point logic.

* **Chores**
  * Updated example and mock implementations to align with new subscription method signatures and abstractions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->