### PR TITLE
Renames RoomReaction.type to RoomReaction.name

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -83,7 +83,7 @@ struct ContentView: View {
 
     private var sendTitle: String {
         if newMessage.isEmpty {
-            ReactionType.like.emoji
+            ReactionName.like.emoji
         } else if editingItemID != nil {
             "Update"
         } else {
@@ -239,7 +239,7 @@ struct ContentView: View {
 
     func sendButtonAction() {
         if newMessage.isEmpty {
-            sendRoomReaction(ReactionType.like.emoji)
+            sendRoomReaction(ReactionName.like.emoji)
         } else if editingItemID != nil {
             Task {
                 try await sendEditedMessage()
@@ -421,7 +421,7 @@ struct ContentView: View {
 
     func sendRoomReaction(_ reaction: String) {
         Task {
-            try await room().reactions.send(params: .init(type: reaction))
+            try await room().reactions.send(params: .init(name: reaction))
         }
     }
 

--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -68,7 +68,7 @@ enum MockStrings {
     }
 }
 
-enum ReactionType: String, CaseIterable {
+enum ReactionName: String, CaseIterable {
     case like, dislike, lol, rofl, ok, idk
 
     var emoji: String {
@@ -91,7 +91,7 @@ enum ReactionType: String, CaseIterable {
 
 extension RoomReaction {
     var displayedText: String {
-        type
+        name
     }
 }
 

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -317,7 +317,7 @@ class MockRoomReactions: RoomReactions {
 
     func send(params: SendReactionParams) async throws(ARTErrorInfo) {
         let reaction = RoomReaction(
-            type: params.type,
+            name: params.name,
             metadata: [:],
             headers: [:],
             createdAt: Date(),
@@ -333,7 +333,7 @@ class MockRoomReactions: RoomReactions {
         mockSubscriptions.create(
             randomElement: {
                 let reaction = RoomReaction(
-                    type: ReactionType.allCases.randomElement()!.emoji,
+                    name: ReactionName.allCases.randomElement()!.emoji,
                     metadata: [:],
                     headers: [:],
                     createdAt: Date(),

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -37,7 +37,7 @@ internal final class DefaultRoomReactions: RoomReactions {
             do {
                 logger.log(message: "Sending reaction with params: \(params)", level: .debug)
 
-                let dto = RoomReactionDTO(type: params.type, metadata: params.metadata, headers: params.headers)
+                let dto = RoomReactionDTO(name: params.name, metadata: params.metadata, headers: params.headers)
 
                 try await channel.publish(
                     RoomReactionEvents.reaction.rawValue,
@@ -82,7 +82,7 @@ internal final class DefaultRoomReactions: RoomReactions {
 
                     // (CHA-ER4d) Realtime events that are malformed (unknown fields should be ignored) shall not be emitted to listeners.
                     let reaction = RoomReaction(
-                        type: dto.type,
+                        name: dto.name,
                         metadata: dto.metadata ?? [:],
                         headers: dto.headers ?? [:],
                         createdAt: timestamp,

--- a/Sources/AblyChat/RoomReaction.swift
+++ b/Sources/AblyChat/RoomReaction.swift
@@ -19,7 +19,7 @@ public struct RoomReaction: Sendable {
     /**
      * The type of the reaction, for example "like" or "love".
      */
-    public var type: String
+    public var name: String
 
     /**
      * Metadata of the reaction. If no metadata was set this is an empty object.
@@ -46,8 +46,8 @@ public struct RoomReaction: Sendable {
      */
     public var isSelf: Bool
 
-    public init(type: String, metadata: ReactionMetadata, headers: ReactionHeaders, createdAt: Date, clientID: String, isSelf: Bool) {
-        self.type = type
+    public init(name: String, metadata: ReactionMetadata, headers: ReactionHeaders, createdAt: Date, clientID: String, isSelf: Bool) {
+        self.name = name
         self.metadata = metadata
         self.headers = headers
         self.createdAt = createdAt

--- a/Sources/AblyChat/RoomReactionDTO.swift
+++ b/Sources/AblyChat/RoomReactionDTO.swift
@@ -4,7 +4,7 @@ internal struct RoomReactionDTO {
     internal var extras: Extras
 
     internal struct Data: Equatable {
-        internal var type: String
+        internal var name: String
         internal var metadata: ReactionMetadata?
     }
 
@@ -14,13 +14,13 @@ internal struct RoomReactionDTO {
 }
 
 internal extension RoomReactionDTO {
-    init(type: String, metadata: ReactionMetadata?, headers: ReactionHeaders?) {
-        data = .init(type: type, metadata: metadata)
+    init(name: String, metadata: ReactionMetadata?, headers: ReactionHeaders?) {
+        data = .init(name: name, metadata: metadata)
         extras = .init(headers: headers)
     }
 
-    var type: String {
-        data.type
+    var name: String {
+        data.name
     }
 
     var metadata: ReactionMetadata? {
@@ -36,18 +36,18 @@ internal extension RoomReactionDTO {
 
 extension RoomReactionDTO.Data: JSONObjectCodable {
     internal enum JSONKey: String {
-        case type
+        case name
         case metadata
     }
 
     internal init(jsonObject: [String: JSONValue]) throws(InternalError) {
-        type = try jsonObject.stringValueForKey(JSONKey.type.rawValue)
+        name = try jsonObject.stringValueForKey(JSONKey.name.rawValue)
         metadata = try jsonObject.optionalObjectValueForKey(JSONKey.metadata.rawValue)
     }
 
     internal var toJSONObject: [String: JSONValue] {
         [
-            JSONKey.type.rawValue: .string(type),
+            JSONKey.name.rawValue: .string(name),
             JSONKey.metadata.rawValue: .object(metadata ?? [:]),
         ]
     }

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -62,14 +62,14 @@ public extension RoomReactions {
 }
 
 /**
- * Params for sending a room-level reactions. Only `type` is mandatory.
+ * Params for sending a room-level reactions. Only `name` is mandatory.
  */
 public struct SendReactionParams: Sendable {
     /**
-     * The type of the reaction, for example an emoji or a short string such as "like".
+     * The name of the reaction, for example an emoji or a short string such as "like".
      * It is the only mandatory parameter to send a room-level reaction.
      */
-    public var type: String
+    public var name: String
 
     /**
      * Optional metadata of the reaction.
@@ -98,8 +98,8 @@ public struct SendReactionParams: Sendable {
      */
     public var headers: ReactionHeaders?
 
-    public init(type: String, metadata: ReactionMetadata? = nil, headers: ReactionHeaders? = nil) {
-        self.type = type
+    public init(name: String, metadata: ReactionMetadata? = nil, headers: ReactionHeaders? = nil) {
+        self.name = name
         self.metadata = metadata
         self.headers = headers
     }

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -15,7 +15,7 @@ struct DefaultRoomReactionsTests {
         let defaultRoomReactions = DefaultRoomReactions(channel: channel, clientID: "mockClientId", roomName: "basketball", logger: TestLogger())
 
         let sendReactionParams = SendReactionParams(
-            type: "like",
+            name: "like",
             metadata: ["someMetadataKey": "someMetadataValue"],
             headers: ["someHeadersKey": "someHeadersValue"]
         )
@@ -25,7 +25,7 @@ struct DefaultRoomReactionsTests {
 
         // Then
         #expect(channel.publishedMessages.last?.name == RoomReactionEvents.reaction.rawValue)
-        #expect(channel.publishedMessages.last?.data == ["type": "like", "metadata": ["someMetadataKey": "someMetadataValue"]])
+        #expect(channel.publishedMessages.last?.data == ["name": "like", "metadata": ["someMetadataKey": "someMetadataValue"]])
         #expect(channel.publishedMessages.last?.extras == ["headers": ["someHeadersKey": "someHeadersValue"], "ephemeral": true])
     }
 
@@ -54,7 +54,7 @@ struct DefaultRoomReactionsTests {
         // When
         let subscription = defaultRoomReactions.subscribe { event in
             // Then
-            #expect(event.reaction.type == ":like:")
+            #expect(event.reaction.name == ":like:")
         }
 
         // CHA-ER4b
@@ -90,7 +90,7 @@ struct DefaultRoomReactionsTests {
 
         // When
         defaultRoomReactions.subscribe { event in
-            #expect(event.reaction.type == ":like:")
+            #expect(event.reaction.name == ":like:")
         }
         // will not be received and expectations above will not fail
         channel.simulateIncomingMessage(

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -326,13 +326,13 @@ struct IntegrationTests {
         // (2) Now that we're subscribed to reactions, send a reaction on the other client and check that we receive it on the subscription
         try await txRoom.reactions.send(
             params: .init(
-                type: "heart",
+                name: "heart",
                 metadata: ["someMetadataKey": 123, "someOtherMetadataKey": "foo"],
                 headers: ["someHeadersKey": 456, "someOtherHeadersKey": "bar"]
             )
         )
         let rxReactionFromSubscription = try #require(await rxReactionSubscription.first { @Sendable _ in true })
-        #expect(rxReactionFromSubscription.reaction.type == "heart")
+        #expect(rxReactionFromSubscription.reaction.name == "heart")
         #expect(rxReactionFromSubscription.reaction.metadata == ["someMetadataKey": .number(123), "someOtherMetadataKey": .string("foo")])
         #expect(rxReactionFromSubscription.reaction.headers == ["someHeadersKey": .number(456), "someOtherHeadersKey": .string("bar")])
 

--- a/Tests/AblyChatTests/RoomReactionDTOTests.swift
+++ b/Tests/AblyChatTests/RoomReactionDTOTests.swift
@@ -25,14 +25,14 @@ enum RoomReactionDTOTests {
 
         @Test
         func initWithJSONValue_withNoMetadataKey() throws {
-            #expect(try RoomReactionDTO.Data(jsonValue: ["type": "" /* arbitrary */ ]).metadata == nil)
+            #expect(try RoomReactionDTO.Data(jsonValue: ["name": "" /* arbitrary */ ]).metadata == nil)
         }
 
         @Test
         func initWithJSONValue() throws {
             let data = try RoomReactionDTO.Data(
                 jsonValue: [
-                    "type": "someType",
+                    "name": "someName",
                     "metadata": [
                         "someStringKey": "someStringValue",
                         "someNumberKey": 123,
@@ -40,7 +40,7 @@ enum RoomReactionDTOTests {
                 ]
             )
 
-            #expect(data == .init(type: "someType", metadata: ["someStringKey": "someStringValue", "someNumberKey": 123]))
+            #expect(data == .init(name: "someName", metadata: ["someStringKey": "someStringValue", "someNumberKey": 123]))
         }
 
         // MARK: - JSONCodable
@@ -48,15 +48,15 @@ enum RoomReactionDTOTests {
         @Test
         func toJSONValue_withNilMetadata() {
             // i.e. should create an empty object for metadata
-            #expect(RoomReactionDTO.Data(type: "" /* arbitrary */, metadata: nil).toJSONValue == .object(["type": "", "metadata": .object([:])]))
+            #expect(RoomReactionDTO.Data(name: "" /* arbitrary */, metadata: nil).toJSONValue == .object(["name": "", "metadata": .object([:])]))
         }
 
         @Test
         func toJSONValue() {
-            let data = RoomReactionDTO.Data(type: "someType", metadata: ["someStringKey": "someStringValue", "someNumberKey": 123])
+            let data = RoomReactionDTO.Data(name: "someName", metadata: ["someStringKey": "someStringValue", "someNumberKey": 123])
 
             #expect(data.toJSONValue == [
-                "type": "someType",
+                "name": "someName",
                 "metadata": [
                     "someStringKey": "someStringValue",
                     "someNumberKey": 123,


### PR DESCRIPTION
Refactors the RoomReaction `type` property to be `name`, in line with expected realtime changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the reaction property from "type" to "name" throughout the app for improved consistency.
  * Updated related enums, struct initializers, and method parameters to use "name" instead of "type".
  * Adjusted JSON encoding/decoding keys and internal logic to reflect this change.

* **Tests**
  * Updated all test cases to use the new "name" property, ensuring alignment with the refactored code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->