### PR TITLE
[ECO-5438] Add the soft delete behaviour and validation loosening

### DIFF
--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -147,7 +147,7 @@ internal final class ChatAPI: Sendable {
             operation: .init(
                 clientID: clientID,
                 description: description,
-                metadata: metadata
+                metadata: metadata ?? [:]
             )
         )
         return message
@@ -186,7 +186,7 @@ internal final class ChatAPI: Sendable {
             operation: .init(
                 clientID: message.clientID,
                 description: params.description,
-                metadata: params.metadata
+                metadata: params.metadata ?? [:]
             )
         )
         return message

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -142,11 +142,11 @@ public struct Message: Sendable, Identifiable, Equatable {
 }
 
 public struct MessageOperation: Sendable, Equatable {
-    public var clientID: String
+    public var clientID: String?
     public var description: String?
     public var metadata: MessageMetadata?
 
-    public init(clientID: String, description: String? = nil, metadata: MessageMetadata? = nil) {
+    public init(clientID: String?, description: String? = nil, metadata: MessageMetadata? = nil) {
         self.clientID = clientID
         self.description = description
         self.metadata = metadata
@@ -159,7 +159,7 @@ extension Message: JSONObjectDecodable {
         let serial = try jsonObject.stringValueForKey("serial")
         var reactionSummary: MessageReactionSummary?
         if let summaryJson = try? jsonObject.objectValueForKey("reactions"), !summaryJson.isEmpty {
-            reactionSummary = try MessageReactionSummary(
+            reactionSummary = MessageReactionSummary(
                 messageSerial: serial,
                 values: summaryJson
             )

--- a/Sources/AblyChat/MessageReaction+JSON.swift
+++ b/Sources/AblyChat/MessageReaction+JSON.swift
@@ -8,7 +8,7 @@ internal extension MessageReactionSummary {
         case multiple
     }
 
-    init(messageSerial: String, values jsonObject: [String: JSONValue]) throws(InternalError) {
+    init(messageSerial: String, values jsonObject: [String: JSONValue]) {
         self.messageSerial = messageSerial
 
         // Two different key are used for now until fixed. Internal discussion:
@@ -24,10 +24,10 @@ internal extension MessageReactionSummary {
                     return try MessageReactionSummary.ClientIdList(jsonObject: uniqueJsonItem)
                 }
             } catch {
-                throw JSONValueDecodingError.failedToDecodeFromRawValue("unique: \(uniqueJson)").toInternalError()
+                unique = [:] // CHA-MR6a
             }
         } else {
-            unique = [:]
+            unique = [:] // CHA-MR6a3
         }
 
         let distinctJson = try? jsonObject.optionalObjectValueForKey(MessageReactionType.distinct.rawValue) ??
@@ -41,10 +41,10 @@ internal extension MessageReactionSummary {
                     return try MessageReactionSummary.ClientIdList(jsonObject: distinctJsonItem)
                 }
             } catch {
-                throw JSONValueDecodingError.failedToDecodeFromRawValue("distinct: \(distinctJson)").toInternalError()
+                distinct = [:] // CHA-MR6a
             }
         } else {
-            distinct = [:]
+            distinct = [:] // CHA-MR6a3
         }
 
         let multipleJson = try? jsonObject.optionalObjectValueForKey(MessageReactionType.multiple.rawValue) ??
@@ -58,10 +58,10 @@ internal extension MessageReactionSummary {
                     return try MessageReactionSummary.ClientIdCounts(jsonObject: multipleJsonItem)
                 }
             } catch {
-                throw JSONValueDecodingError.failedToDecodeFromRawValue("multiple: \(multipleJson)").toInternalError()
+                multiple = [:] // CHA-MR6a
             }
         } else {
-            multiple = [:]
+            multiple = [:] // CHA-MR6a3
         }
     }
 }

--- a/Sources/AblyChat/MessageReaction.swift
+++ b/Sources/AblyChat/MessageReaction.swift
@@ -1,4 +1,4 @@
-import Foundation
+import Ably
 
 /**
  * Enum representing different message reaction events in the chat system.
@@ -16,6 +16,19 @@ public enum MessageReactionEvent: String, Sendable {
      * A reactions summary was updated for a message.
      */
     case summary = "reaction.summary"
+}
+
+internal extension MessageReactionEvent {
+    static func fromAnnotationAction(_ annotationAction: ARTAnnotationAction) -> Self? {
+        switch annotationAction {
+        case .create:
+            .create
+        case .delete:
+            .delete
+        @unknown default:
+            nil
+        }
+    }
 }
 
 /**

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -145,9 +145,8 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
     func subscribe(_ name: String, callback: @escaping @MainActor (ARTMessage) -> Void) -> ARTEventListener? {
         if let messageToEmitOnSubscribe {
             callback(messageToEmitOnSubscribe)
-        } else {
-            channelSubscriptions.append((name, callback))
         }
+        channelSubscriptions.append((name, callback))
         return ARTEventListener()
     }
 


### PR DESCRIPTION
Closes #321 

Add the soft delete behaviour and validation loosening
Fix room reaction tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or incomplete chat and reaction events, ensuring default values are used and errors are logged instead of causing failures.
  * Ensured message metadata is never nil in updated and deleted messages.

* **Refactor**
  * Streamlined error handling in message and reaction event processing for greater robustness and clarity.
  * Updated internal data handling to use optional values and fallbacks for missing fields.
  * Removed throwing initializers and replaced error propagation with silent fallback defaults during JSON decoding.

* **Tests**
  * Enhanced tests to verify that events with incomplete data are still emitted with default values.
  * Updated test cases and assertions to match new data handling logic.
  * Improved subscription tracking and callback invocation assertions.

* **New Features**
  * Added a utility method for mapping annotation actions to reaction events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->