### PR TITLE
[ECO-5429] Message reactions tests

### DIFF
--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -199,7 +199,7 @@ internal final class ChatAPI: Sendable {
 
     // (CHA-MR4) Users should be able to send a reaction to a message via the `send` method of the `MessagesReactions` object
     internal func sendReactionToMessage(_ messageSerial: String, roomName: String, params: SendMessageReactionParams) async throws(InternalError) -> MessageReactionResponse {
-        // (CHA-MR11a1) If the serial passed to this method is invalid: undefined, null, empty string, an error with code 40000 must be thrown.
+        // (CHA-MR4a1) If the serial passed to this method is invalid: undefined, null, empty string, an error with code 40000 must be thrown.
         guard !messageSerial.isEmpty else {
             throw ChatError.messageReactionInvalidMessageSerial.toInternalError()
         }

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -68,7 +68,7 @@ internal final class ChatAPI: Sendable {
     // (CHA-M3a) When a message is sent successfully, the caller shall receive a struct representing the Message in response (as if it were received via Realtime event).
     internal func sendMessage(roomName: String, params: SendMessageParams) async throws(InternalError) -> Message {
         guard let clientId = realtime.clientId else {
-            throw ARTErrorInfo.create(withCode: 40000, message: "Ensure your Realtime instance is initialized with a clientId.").toInternalError()
+            throw ARTErrorInfo(chatError: .clientIdRequired).toInternalError()
         }
 
         let endpoint = "\(apiVersionV3)/rooms/\(roomName)/messages"
@@ -106,7 +106,7 @@ internal final class ChatAPI: Sendable {
     // (CHA-M8a) A client may update a message via the Chat REST API by calling the update method.
     internal func updateMessage(roomName: String, with modifiedMessage: Message, description: String?, metadata: OperationMetadata?) async throws(InternalError) -> Message {
         guard let clientID = realtime.clientId else {
-            throw ARTErrorInfo.create(withCode: 40000, message: "Ensure your Realtime instance is initialized with a clientId.").toInternalError()
+            throw ARTErrorInfo(chatError: .clientIdRequired).toInternalError()
         }
 
         let endpoint = "\(apiVersionV3)/rooms/\(roomName)/messages/\(modifiedMessage.serial)"

--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -63,6 +63,7 @@ public enum ErrorCode: Int {
         case cannotApplyEventForDifferentMessage
         case messageRejectedByBeforePublishRule
         case messageRejectedByModeration
+        case clientIdRequired
 
         internal var toNumericErrorCode: ErrorCode {
             switch self {
@@ -86,6 +87,8 @@ public enum ErrorCode: Int {
                 .messageRejectedByModeration
             case .messageRejectedByBeforePublishRule:
                 .messageRejectedByBeforePublishRule
+            case .clientIdRequired:
+                .badRequest
             }
         }
 
@@ -99,7 +102,8 @@ public enum ErrorCode: Int {
                  .roomIsReleased,
                  .roomReleasedBeforeOperationCompleted,
                  .unableDeleteReactionWithoutName,
-                 .cannotApplyEventForDifferentMessage:
+                 .cannotApplyEventForDifferentMessage,
+                 .clientIdRequired:
                 400
             case .messageRejectedByModeration,
                  .messageRejectedByBeforePublishRule:
@@ -170,6 +174,7 @@ internal enum ChatError {
     case cannotApplyEventForDifferentMessage
     case messageRejectedByBeforePublishRule
     case messageRejectedByModeration
+    case clientIdRequired
 
     internal var codeAndStatusCode: ErrorCodeAndStatusCode {
         switch self {
@@ -202,6 +207,8 @@ internal enum ChatError {
             .fixedStatusCode(.messageRejectedByBeforePublishRule)
         case .messageRejectedByModeration:
             .fixedStatusCode(.messageRejectedByModeration)
+        case .clientIdRequired:
+            .fixedStatusCode(.clientIdRequired)
         }
     }
 
@@ -256,6 +263,8 @@ internal enum ChatError {
             "The message was rejected before publishing by a rule on the chat room."
         case .messageRejectedByModeration:
             "The message was rejected before publishing by a moderation rule on the chat room."
+        case .clientIdRequired:
+            "Ensure your Realtime instance is initialized with a clientId."
         }
     }
 
@@ -276,7 +285,8 @@ internal enum ChatError {
              .cannotApplyEventForDifferentMessage,
              .unableDeleteReactionWithoutName,
              .messageRejectedByBeforePublishRule,
-             .messageRejectedByModeration:
+             .messageRejectedByModeration,
+             .clientIdRequired:
             nil
         }
     }

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -265,7 +265,7 @@ internal class DefaultRoom: InternalRoom {
         self.chatAPI = chatAPI
 
         guard let clientId = realtime.clientId else {
-            throw ARTErrorInfo.create(withCode: 40000, message: "Ensure your Realtime instance is initialized with a clientId.").toInternalError()
+            throw ARTErrorInfo(chatError: .clientIdRequired).toInternalError()
         }
 
         internalChannel = Self.createChannel(roomName: name, roomOptions: options, realtime: realtime)

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -301,7 +301,7 @@ struct SpecCoverage: AsyncParsableCommand {
                 // ** @(CHA-RS4b)@ @[Testable]@ Room status update events must contain the previous room status.
                 // (This `Testable` is a convention that’s being used only in the Chat spec)
 
-                let specPointLineRegex = /^\*+ @\((.*?)\)@( @\[Testable\]@ )?/
+                let specPointLineRegex = /^\s*\*+ @\((.*?)\)@( @\[Testable\]@ )?/
 
                 // swiftlint:disable:next force_try
                 guard let match = try! specPointLineRegex.firstMatch(in: specLine) else {

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -4,6 +4,111 @@ import Testing
 
 @MainActor
 struct DefaultMessageReactionsTests {
+    // @spec CHA-MR4
+    // @spec CHA-MR4a
+    // @spec CHA-MR4b
+    // @spec CHA-MR11
+    // @spec CHA-MR11a
+    // @spec CHA-MR11b
+    // @spec CHA-MR11b1
+    // @spec CHA-MR11b2
+    @Test
+    func sendAndDeleteReactionForMessage() async throws {
+        // Given
+        let realtime = MockRealtime {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let chatAPI = ChatAPI(realtime: realtime)
+        let channel = MockRealtimeChannel(initialState: .attached)
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
+
+        // When
+        let message = try await defaultMessages.send(params: .init(text: "a joke"))
+        try await defaultMessages.reactions.send(to: message.serial, params: .init(name: "😆", type: .multiple, count: 10))
+        try await defaultMessages.reactions.delete(from: message.serial, params: .init(name: "😆", type: .multiple))
+
+        // Then
+        #expect(realtime.callRecorder.hasRecord(
+            matching: "request(_:path:params:body:headers:)",
+            arguments: [
+                "method": "POST",
+                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "body": [
+                    "name": "😆",
+                    "type": "reaction:multiple.v1",
+                    "count": 10,
+                ],
+                "params": [:],
+                "headers": [:],
+            ]
+        )
+        )
+        #expect(realtime.callRecorder.hasRecord(
+            matching: "request(_:path:params:body:headers:)",
+            arguments: [
+                "method": "DELETE",
+                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "body": [:],
+                "params": [
+                    "name": "😆",
+                    "type": "reaction:multiple.v1",
+                ],
+                "headers": [:],
+            ]
+        )
+        )
+    }
+
+    // @spec CHA-MR4a1
+    @Test
+    func errorShouldBeThrownIfMessageSerialIsEmptyWhenSend() async throws {
+        // Given
+        let realtime = MockRealtime {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let chatAPI = ChatAPI(realtime: realtime)
+        let channel = MockRealtimeChannel(initialState: .attached)
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
+
+        let doIt = {
+            // When
+            try await defaultMessages.reactions.send(to: "", params: .init(name: "😐", type: .distinct))
+        }
+        await #expect {
+            try await doIt()
+        } throws: { error in
+            // Then
+            error as? ARTErrorInfo == ARTErrorInfo(chatError: .nonErrorInfoInternalError(.chatAPIChatError(.messageReactionInvalidMessageSerial)))
+        }
+    }
+
+    // @spec CHA-MR11a1
+    @Test
+    func errorShouldBeThrownIfMessageSerialIsEmptyWhenDelete() async throws {
+        // Given
+        let realtime = MockRealtime {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let chatAPI = ChatAPI(realtime: realtime)
+        let channel = MockRealtimeChannel(initialState: .attached)
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
+
+        let doIt = {
+            // When
+            try await defaultMessages.reactions.delete(from: "", params: .init(name: "😐", type: .distinct))
+        }
+        await #expect {
+            try await doIt()
+        } throws: { error in
+            // Then
+            error as? ARTErrorInfo == ARTErrorInfo(chatError: .nonErrorInfoInternalError(.chatAPIChatError(.messageReactionInvalidMessageSerial)))
+        }
+    }
+
+    // @spec CHA-MR3
+    // @spec CHA-MR3b
+    // @spec CHA-MR3b2
+    // @spec CHA-MR3b3
     // @spec CHA-MR6
     @Test
     func subscribeToMessageReactionSummaries() async throws {
@@ -12,10 +117,6 @@ struct DefaultMessageReactionsTests {
         let chatAPI = ChatAPI(realtime: realtime)
 
         let channel = MockRealtimeChannel(
-            properties: .init(
-                attachSerial: "001",
-                channelSerial: "001"
-            ),
             initialState: .attached,
             messageToEmitOnSubscribe: {
                 let message = ARTMessage()
@@ -41,30 +142,68 @@ struct DefaultMessageReactionsTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
+        var callbackCalls = 0
         defaultMessages.reactions.subscribe { event in
             // Then
             #expect(event.type == .summary)
+            #expect(type(of: event.summary.unique) == [String: MessageReactionSummary.ClientIdList].self)
             #expect(event.summary.unique["like"]?.total == 2)
             #expect(event.summary.unique["love"]?.total == 1)
+            #expect(event.summary.unique["like"]?.clientIds.count == 2)
+            #expect(event.summary.unique["love"]?.clientIds.count == 1)
+            #expect(type(of: event.summary.distinct) == [String: MessageReactionSummary.ClientIdList].self)
             #expect(event.summary.distinct["like"]?.total == 2)
             #expect(event.summary.distinct["love"]?.total == 1)
+            #expect(event.summary.distinct["like"]?.clientIds.count == 2)
+            #expect(event.summary.distinct["love"]?.clientIds.count == 1)
+            #expect(type(of: event.summary.multiple) == [String: MessageReactionSummary.ClientIdCounts].self)
             #expect(event.summary.multiple["like"]?.total == 5)
             #expect(event.summary.multiple["love"]?.total == 10)
+            #expect(event.summary.multiple["like"]?.clientIds.count == 2)
+            #expect(event.summary.multiple["love"]?.clientIds.count == 1)
+            callbackCalls += 1
         }
+        #expect(callbackCalls == 1)
+    }
+
+    // @spec CHA-MR6a
+    // @spec CHA-MR6a3
+    @Test
+    func invalidReactionSummaryEventsMustStillProduceEventWithDefaultValues() async throws {
+        // Given
+        let realtime = MockRealtime()
+        let chatAPI = ChatAPI(realtime: realtime)
+
+        let channel = MockRealtimeChannel(
+            initialState: .attached,
+            messageToEmitOnSubscribe: {
+                let message = ARTMessage()
+                message.serial = "001"
+                message.action = .messageSummary
+                return message
+            }()
+        )
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
+
+        // When
+        var callbackCalls = 0
+        defaultMessages.reactions.subscribe { event in
+            // Then
+            #expect(event.type == .summary)
+            #expect(event.summary.unique.isEmpty)
+            #expect(event.summary.distinct.isEmpty)
+            #expect(event.summary.multiple.isEmpty)
+            callbackCalls += 1
+        }
+        #expect(callbackCalls == 1)
     }
 
     // @spec CHA-MR7
     @Test
     func subscribeToRawMessageReactions() async throws {
         // Given
-        let realtime = MockRealtime()
-        let chatAPI = ChatAPI(realtime: realtime)
-
         let channel = MockRealtimeChannel(
-            properties: .init(
-                attachSerial: "001",
-                channelSerial: "001"
-            ),
+            name: "basketball::$chat",
             initialState: .attached,
             annotationToEmitOnSubscribe: .init(
                 id: nil,
@@ -81,9 +220,17 @@ struct DefaultMessageReactionsTests {
                 extras: nil
             )
         )
-        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
+        let channels = MockChannels(channels: [channel])
+        let realtime = MockRealtime(channels: channels) {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let roomOptions = RoomOptions(messages: .init(rawMessageReactions: true))
+        let room = try DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), name: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        let defaultMessages = room.messages
 
         // When
+        var callbackCalls = 0
         defaultMessages.reactions.subscribeRaw { event in
             // Then
             #expect(event.type == MessageReactionEvent.create)
@@ -92,6 +239,174 @@ struct DefaultMessageReactionsTests {
             #expect(event.reaction.clientID == "U3BpZGVyd2Vi")
             #expect(event.reaction.messageSerial == "0LHQtdC70YvQtSDRgNC+0LfRiw")
             #expect(event.reaction.count == 41)
+            callbackCalls += 1
         }
+        #expect(callbackCalls == 1)
     }
+
+    // @spec CHA-MR7b
+    // @spec CHA-MR7b3
+    @Test
+    func invalidReactionEventsMustStillProduceEventWithDefaultValues() async throws {
+        // Given
+        let channel = MockRealtimeChannel(
+            name: "basketball::$chat",
+            initialState: .attached,
+            annotationToEmitOnSubscribe: .init(
+                id: nil,
+                action: .create,
+                clientId: nil,
+                name: nil,
+                count: nil,
+                data: nil,
+                encoding: nil,
+                timestamp: Date(),
+                serial: "",
+                messageSerial: "",
+                type: "reaction:multiple.v1",
+                extras: nil
+            )
+        )
+        let channels = MockChannels(channels: [channel])
+        let realtime = MockRealtime(channels: channels) {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let roomOptions = RoomOptions(messages: .init(rawMessageReactions: true))
+        let room = try DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), name: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        let defaultMessages = room.messages
+
+        // When
+        var callbackCalls = 0
+        defaultMessages.reactions.subscribeRaw { event in
+            // Then
+            #expect(event.reaction.name.isEmpty)
+            #expect(event.reaction.clientID.isEmpty)
+            callbackCalls += 1
+        }
+        #expect(callbackCalls == 1)
+    }
+
+    // @spec CHA-MR7b1
+    @Test
+    func ifReactionTypeIsUnknownTheEventShallBeIgnored() async throws {
+        // Given
+        let channel = MockRealtimeChannel(
+            name: "basketball::$chat",
+            initialState: .attached,
+            annotationToEmitOnSubscribe: .init(
+                id: nil,
+                action: .create,
+                clientId: nil,
+                name: nil,
+                count: nil,
+                data: nil,
+                encoding: nil,
+                timestamp: Date(),
+                serial: "",
+                messageSerial: "",
+                type: "not-a-reaction", // invalid type
+                extras: nil
+            )
+        )
+        let channels = MockChannels(channels: [channel])
+        let realtime = MockRealtime(channels: channels) {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let roomOptions = RoomOptions(messages: .init(rawMessageReactions: true))
+        let room = try DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), name: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        let defaultMessages = room.messages
+
+        // When
+        var callbackCalls = 0
+        defaultMessages.reactions.subscribeRaw { _ in
+            callbackCalls += 1
+        }
+        // Then
+        #expect(callbackCalls == 0)
+    }
+
+    // @specOneOf(1/2) CHA-MR5
+    @Test
+    func configureDefaultMessageReactionTypeForRoom() async throws {
+        // Given
+        let channel = MockRealtimeChannel(
+            name: "basketball::$chat",
+            initialState: .attached
+        )
+        let channels = MockChannels(channels: [channel])
+        let realtime = MockRealtime(channels: channels) {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let roomOptions = RoomOptions(messages: .init(defaultMessageReactionType: .multiple))
+        let room = try DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), name: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        let defaultMessages = room.messages
+
+        // When
+        let message = try await defaultMessages.send(params: .init(text: "a joke"))
+        try await defaultMessages.reactions.send(to: message.serial, params: .init(name: "😆"))
+
+        // Then
+        #expect(realtime.callRecorder.hasRecord(
+            matching: "request(_:path:params:body:headers:)",
+            arguments: [
+                "method": "POST",
+                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "body": [
+                    "name": "😆",
+                    "type": "reaction:multiple.v1",
+                    "count": 1,
+                ],
+                "params": [:],
+                "headers": [:],
+            ]
+        )
+        )
+    }
+
+    // @specOneOf(2/2) CHA-MR5
+    @Test
+    func reactionTypeForRoomIsDistinctByDefault() async throws {
+        // Given: a DefaultRoom instance
+        let channel = MockRealtimeChannel(
+            name: "basketball::$chat",
+            initialState: .attached
+        )
+        let channels = MockChannels(channels: [channel])
+        let realtime = MockRealtime(channels: channels) {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let roomOptions = RoomOptions()
+        let room = try DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), name: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        // Then
+        let defaultMessages = room.messages
+
+        // When
+        let message = try await defaultMessages.send(params: .init(text: "a joke"))
+        try await defaultMessages.reactions.send(to: message.serial, params: .init(name: "😆"))
+
+        // Then
+        #expect(realtime.callRecorder.hasRecord(
+            matching: "request(_:path:params:body:headers:)",
+            arguments: [
+                "method": "POST",
+                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "body": [
+                    "name": "😆",
+                    "type": "reaction:distinct.v1",
+                    "count": 1,
+                ],
+                "params": [:],
+                "headers": [:],
+            ]
+        )
+        )
+    }
+
+    // @specNotApplicable CHA-MR7a - It's a programmer error to call `Room.messages.reactions.subscribeRaw` without `MessageOptions.rawMessageReactions` being set to `true`.
+
+    // @specNotApplicable CHA-MR3a - Summary is a `NSDictionary` of wire values in the cocoa SDK.
 }


### PR DESCRIPTION
Closes #304 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of default reaction options and improved error handling for raw message reactions.
  * Simplified logic for reaction name assignment in raw reaction subscriptions.
  * Updated error reporting to use standardized chat error codes for message sending and updating.
  * Enhanced parsing flexibility for specification coverage by allowing leading whitespace in spec point lines.

* **Tests**
  * Added extensive tests for sending, deleting, and subscribing to message reactions, including error handling and configuration scenarios.
  * Improved coverage for reaction summary and raw event subscriptions, ensuring robust validation of reaction behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->