### PR TITLE
[ECO-5441] Message update and delete tests

### DIFF
--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -128,6 +128,7 @@ internal final class ChatAPI: Sendable {
         }
 
         // (CHA-M8c) An update operation has PUT semantics. If a field is not specified in the update, it is assumed to be removed.
+        // CHA-M8c is not actually respected here, see https://github.com/ably/ably-chat-swift/issues/333
         let response: UpdateMessageResponse = try await makeRequest(endpoint, method: "PUT", body: .jsonObject(body))
 
         // response.timestamp is in milliseconds, convert it to seconds
@@ -177,10 +178,10 @@ internal final class ChatAPI: Sendable {
             serial: message.serial,
             action: .delete,
             clientID: message.clientID,
-            text: message.text,
+            text: "", // CHA-M9b
             createdAt: message.createdAt,
-            metadata: message.metadata,
-            headers: message.headers,
+            metadata: [:], // CHA-M9b
+            headers: [:], // CHA-M9b
             version: response.version,
             timestamp: Date(timeIntervalSince1970: timestampInSeconds),
             operation: .init(

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -178,7 +178,7 @@ internal final class ChatAPI: Sendable {
             serial: message.serial,
             action: .delete,
             clientID: message.clientID,
-            text: "", // CHA-M9b
+            text: "", // CHA-M9b (When a message is deleted successfully via the REST API, the caller shall receive a struct representing the Message in response, as if it were received via Realtime event.) Currently realtime sends an empty text for deleted message, so set it to empty text here as well.
             createdAt: message.createdAt,
             metadata: [:], // CHA-M9b
             headers: [:], // CHA-M9b

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -59,6 +59,8 @@ extension MockHTTPPaginatedResponse {
         items: [
             [
                 "serial": "3446456",
+                "version": "3446456",
+                "timestamp": 1_631_840_000_000,
                 "createdAt": 1_631_840_000_000,
                 "text": "hello",
             ],


### PR DESCRIPTION
Closes #324 

Tests for message update and delete didn't exist, so I've added them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured deleted messages return empty text, metadata, and headers for consistency.
  * Clarified message update behavior in line with protocol specifications.

* **Tests**
  * Expanded tests to cover sending, updating, and deleting messages with metadata and headers.
  * Added tests for error handling in update and delete operations.
  * Enhanced mock responses with version and timestamp fields for improved test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->