### PR TITLE
[ECO-5431] Return realtime connection status/error

### DIFF
--- a/Sources/AblyChat/Connection.swift
+++ b/Sources/AblyChat/Connection.swift
@@ -106,22 +106,22 @@ public enum ConnectionStatus: Sendable {
      */
     case failed
 
-    internal init(from realtimeConnectionState: ARTRealtimeConnectionState) {
-        switch realtimeConnectionState {
+    internal static func fromRealtimeConnectionState(_ state: ARTRealtimeConnectionState) -> Self {
+        switch state {
         case .initialized:
-            self = .initialized
+            .initialized
         case .connecting:
-            self = .connecting
+            .connecting
         case .connected:
-            self = .connected
+            .connected
         case .disconnected:
-            self = .disconnected
+            .disconnected
         case .suspended:
-            self = .suspended
+            .suspended
         case .failed, .closing, .closed:
-            self = .failed
+            .failed
         @unknown default:
-            self = .failed
+            .failed
         }
     }
 }


### PR DESCRIPTION
Closes #314 

Return realtime connection status/error directly instead of updating local variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how connection status and error information are accessed, making them reflect the real-time state directly without maintaining redundant local state.
  * Simplified internal logic for handling connection state changes, resulting in a more streamlined and reliable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->