### PR TITLE
Message payload v4

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "1ceb92e31c2ae82acbe1b60072e8a24852977282d2ec582907a80f43b395de8e",
+  "originHash" : "7373b89d4fcef3a02eb97f027e036fd3dae98fe4c28c855f3d91a8a862a75057",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "05c9a9529c67a9a1d82e4f51d359df9e0a20b299",
-        "version" : "1.2.41"
+        "revision" : "c28983fbdfee1327a4073620af255fd3b1b44b4c",
+        "version" : "1.2.46"
+      }
+    },
+    {
+      "identity" : "ably-cocoa-plugin-support",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ably/ably-cocoa-plugin-support",
+      "state" : {
+        "revision" : "8db4632b0664b7272d54f7b612ddad0a18d1758f",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -15,12 +15,13 @@ final class MockMessagesPaginatedResult: PaginatedResult {
                 action: .create,
                 clientID: self.clientID,
                 text: MockStrings.randomPhrase(),
-                createdAt: Date(),
                 metadata: [:],
                 headers: [:],
-                version: "",
-                timestamp: Date(),
-                operation: nil
+                version: .init(
+                    serial: "",
+                    timestamp: Date()
+                ),
+                timestamp: Date()
             )
         }
     }

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -130,12 +130,13 @@ class MockMessages: Messages {
                     action: .create,
                     clientID: MockStrings.names.randomElement()!,
                     text: MockStrings.randomPhrase(),
-                    createdAt: Date(),
                     metadata: [:],
                     headers: [:],
-                    version: "",
-                    timestamp: Date(),
-                    operation: nil
+                    version: .init(
+                        serial: "",
+                        timestamp: Date()
+                    ),
+                    timestamp: Date()
                 )
                 if byChance(30) { /* 30% of the messages will get the reaction */
                     self.mockReactions.messageSerials.append(message.serial)
@@ -161,12 +162,13 @@ class MockMessages: Messages {
             action: .create,
             clientID: clientID,
             text: params.text,
-            createdAt: Date(),
             metadata: params.metadata ?? [:],
             headers: params.headers ?? [:],
-            version: "",
-            timestamp: Date(),
-            operation: nil
+            version: .init(
+                serial: "",
+                timestamp: Date()
+            ),
+            timestamp: Date()
         )
         mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message
@@ -178,12 +180,10 @@ class MockMessages: Messages {
             action: .update,
             clientID: clientID,
             text: newMessage.text,
-            createdAt: Date(),
             metadata: newMessage.metadata,
             headers: newMessage.headers,
-            version: "\(Date().timeIntervalSince1970)",
-            timestamp: Date(),
-            operation: .init(clientID: clientID)
+            version: .init(serial: "\(Date().timeIntervalSince1970)", timestamp: Date(), clientID: clientID),
+            timestamp: Date()
         )
         mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message
@@ -195,12 +195,14 @@ class MockMessages: Messages {
             action: .delete,
             clientID: clientID,
             text: message.text,
-            createdAt: Date(),
             metadata: message.metadata,
             headers: message.headers,
-            version: "\(Date().timeIntervalSince1970)",
-            timestamp: Date(),
-            operation: .init(clientID: clientID)
+            version: .init(
+                serial: "\(Date().timeIntervalSince1970)",
+                timestamp: Date(),
+                clientID: clientID
+            ),
+            timestamp: Date()
         )
         mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "130760bd033e28534695304b0dca1a7a183f37145284f7399dec4c704726635d",
+  "originHash" : "040d3314a23b369d455e94613c37cb84769c44540e00714a0df8272f0a78a297",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "05c9a9529c67a9a1d82e4f51d359df9e0a20b299",
-        "version" : "1.2.41"
+        "revision" : "c28983fbdfee1327a4073620af255fd3b1b44b4c",
+        "version" : "1.2.46"
+      }
+    },
+    {
+      "identity" : "ably-cocoa-plugin-support",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ably/ably-cocoa-plugin-support",
+      "state" : {
+        "revision" : "8db4632b0664b7272d54f7b612ddad0a18d1758f",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.41"
+            from: "1.2.46"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -72,7 +72,7 @@ internal final class DefaultMessageReactions: MessageReactions {
             }
 
             var summaryJson: [String: JSONValue]?
-            if let summaryData = message.summary {
+            if let summaryData = message.annotations?.summary {
                 summaryJson = JSONValue(ablyCocoaData: summaryData).objectValue
             }
 

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -63,18 +63,25 @@ internal final class DefaultMessages: Messages {
             }
 
             let headers = (try? extras.optionalObjectValueForKey("headers"))?.compactMapValues { try? HeadersValue(jsonValue: $0) } ?? [:] // CHA-M4k2
+            let version = message.version ?? .init()
+            let timestamp = message.timestamp ?? Date(timeIntervalSince1970: 0) // CHA-M4k5
+            let serial = message.serial ?? "" // CHA-M4k1
 
             let message = Message(
-                serial: message.serial ?? "", // CHA-M4k1
+                serial: serial,
                 action: action,
                 clientID: message.clientId ?? "", // CHA-M4k1
                 text: text,
-                createdAt: message.timestamp ?? Date(timeIntervalSince1970: 0), // CHA-M4k4
                 metadata: metadata,
                 headers: headers,
-                version: message.version ?? "", // CHA-M4k1
-                timestamp: message.timestamp ?? Date(), // CHA-M4k3,
-                operation: message.operation?.toChatOperation()
+                version: .init(
+                    serial: version.serial ?? serial, // CHA-M4k6
+                    timestamp: version.timestamp ?? timestamp, // CHA-M4k7
+                    clientID: version.clientId ?? "", // CHA-M4k1
+                    description: version.descriptionText,
+                    metadata: version.metadata?.mapValues { .string($0) } ?? [:] // CHA-M4k2
+                ),
+                timestamp: timestamp
             )
 
             let event = ChatMessageEvent(message: message)
@@ -179,15 +186,5 @@ internal final class DefaultMessages: Messages {
 
     internal enum MessagesError: Error {
         case noReferenceToSelf
-    }
-}
-
-private extension ARTMessageOperation {
-    func toChatOperation() -> MessageOperation {
-        MessageOperation(
-            clientID: clientId ?? "", // CHA-M4k1
-            description: descriptionText,
-            metadata: JSONValue(ablyCocoaData: metadata ?? [:]).objectValue // CHA-M4k2
-        )
     }
 }

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -252,7 +252,7 @@ internal final class DefaultPresence: Presence {
                 clientID: member.clientId ?? "", // CHA-M4k1
                 data: member.data,
                 extras: member.extras,
-                updatedAt: member.timestamp ?? Date() // CHA-M4k3
+                updatedAt: member.timestamp ?? Date(timeIntervalSince1970: 0) // CHA-M4k5
             )
 
             logger.log(message: "Returning presence member: \(presenceMember)", level: .debug)
@@ -266,7 +266,7 @@ internal final class DefaultPresence: Presence {
             clientID: message.clientId ?? "", // CHA-M4k1
             data: message.data,
             extras: message.extras,
-            updatedAt: message.timestamp ?? Date() // CHA-M4k3
+            updatedAt: message.timestamp ?? Date(timeIntervalSince1970: 0) // CHA-M4k5
         )
 
         let presenceEvent = PresenceEvent(

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -49,10 +49,9 @@ struct ChatAPITests {
             action: .create,
             clientID: "mockClientId",
             text: "hello",
-            createdAt: Date(timeIntervalSince1970: 1_631_840_000),
             metadata: [:],
             headers: [:],
-            version: "3446456",
+            version: .init(serial: "3446456", timestamp: Date()),
             timestamp: Date(timeIntervalSince1970: 1_631_840_000)
         )
         #expect(message == expectedMessage)
@@ -130,7 +129,7 @@ struct ChatAPITests {
 
     // @specOneOf(2/2) CHA-M6
     @Test
-    func getMessages_whenGetMessagesReturnsItems_returnsItemsInPaginatedResult() async {
+    func getMessages_whenGetMessagesReturnsItems_returnsItemsInPaginatedResult() async throws {
         // Given
         let paginatedResponse = MockHTTPPaginatedResponse.successGetMessagesWithItems
         let realtime = MockRealtime {
@@ -146,10 +145,9 @@ struct ChatAPITests {
                     action: .create,
                     clientID: "random",
                     text: "hello",
-                    createdAt: .init(timeIntervalSince1970: 1_730_943_049.269),
                     metadata: [:],
                     headers: [:],
-                    version: "3446456",
+                    version: .init(serial: "3446456", timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)), // from successGetMessagesWithItems
                     timestamp: Date(timeIntervalSince1970: 1_730_943_049.269)
                 ),
                 Message(
@@ -157,17 +155,16 @@ struct ChatAPITests {
                     action: .create,
                     clientID: "random",
                     text: "hello response",
-                    createdAt: nil,
                     metadata: [:],
                     headers: [:],
-                    version: "3446457",
-                    timestamp: nil
+                    version: .init(serial: "3446457", timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)),
+                    timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)
                 ),
             ]
         )
 
         // When
-        let getMessagesResult = try? await chatAPI.getMessages(roomName: roomName, params: .init()) as? PaginatedResultWrapper<Message>
+        let getMessagesResult = try #require(await chatAPI.getMessages(roomName: roomName, params: .init()) as? PaginatedResultWrapper<Message>)
 
         // Then
         #expect(getMessagesResult == expectedPaginatedResult)

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -32,7 +32,7 @@ struct DefaultMessageReactionsTests {
             matching: "request(_:path:params:body:headers:)",
             arguments: [
                 "method": "POST",
-                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "path": "/chat/v4/rooms/basketball/messages/\(message.serial)/reactions",
                 "body": [
                     "name": "😆",
                     "type": "reaction:multiple.v1",
@@ -47,7 +47,7 @@ struct DefaultMessageReactionsTests {
             matching: "request(_:path:params:body:headers:)",
             arguments: [
                 "method": "DELETE",
-                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "path": "/chat/v4/rooms/basketball/messages/\(message.serial)/reactions",
                 "body": [:],
                 "params": [
                     "name": "😆",
@@ -122,20 +122,22 @@ struct DefaultMessageReactionsTests {
                 let message = ARTMessage()
                 message.serial = "001"
                 message.action = .messageSummary
-                message.summary = [
-                    "reaction:unique.v1": [
-                        "like": ["total": 2, "clientIds": ["userOne", "userTwo"]],
-                        "love": ["total": 1, "clientIds": ["userThree"]],
-                    ],
-                    "reaction:distinct.v1": [
-                        "like": ["total": 2, "clientIds": ["userOne", "userTwo"]],
-                        "love": ["total": 1, "clientIds": ["userOne"]],
-                    ],
-                    "reaction:multiple.v1": [
-                        "like": ["total": 5, "clientIds": ["userOne": 3, "userTwo": 2]],
-                        "love": ["total": 10, "clientIds": ["userOne": 10]],
-                    ],
-                ]
+                message.annotations = .init(
+                    summary: [
+                        "reaction:unique.v1": [
+                            "like": ["total": 2, "clientIds": ["userOne", "userTwo"]],
+                            "love": ["total": 1, "clientIds": ["userThree"]],
+                        ],
+                        "reaction:distinct.v1": [
+                            "like": ["total": 2, "clientIds": ["userOne", "userTwo"]],
+                            "love": ["total": 1, "clientIds": ["userOne"]],
+                        ],
+                        "reaction:multiple.v1": [
+                            "like": ["total": 5, "clientIds": ["userOne": 3, "userTwo": 2]],
+                            "love": ["total": 10, "clientIds": ["userOne": 10]],
+                        ],
+                    ]
+                )
                 return message
             }()
         )
@@ -353,7 +355,7 @@ struct DefaultMessageReactionsTests {
             matching: "request(_:path:params:body:headers:)",
             arguments: [
                 "method": "POST",
-                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "path": "/chat/v4/rooms/basketball/messages/\(message.serial)/reactions",
                 "body": [
                     "name": "😆",
                     "type": "reaction:multiple.v1",
@@ -393,7 +395,7 @@ struct DefaultMessageReactionsTests {
             matching: "request(_:path:params:body:headers:)",
             arguments: [
                 "method": "POST",
-                "path": "/chat/v3/rooms/basketball/messages/\(message.serial)/reactions",
+                "path": "/chat/v4/rooms/basketball/messages/\(message.serial)/reactions",
                 "body": [
                     "name": "😆",
                     "type": "reaction:distinct.v1",

--- a/Tests/AblyChatTests/DefaultRoomOccupancyTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomOccupancyTests.swift
@@ -63,7 +63,7 @@ struct DefaultRoomOccupancyTests {
                         "presenceMembers": 2, // arbitrary
                     ],
                 ]
-                message.version = "0" // arbitrary
+                message.version = .init(serial: "0") // arbitrary
                 return message
             }()
         )

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -42,7 +42,7 @@ struct DefaultRoomReactionsTests {
             message.data = [
                 "name": reaction,
             ]
-            message.version = "0"
+            message.version = .init(serial: "0")
             message.extras = [String: String]() as ARTJsonCompatible
             return message
         }

--- a/Tests/AblyChatTests/Helpers/Helpers.swift
+++ b/Tests/AblyChatTests/Helpers/Helpers.swift
@@ -175,3 +175,17 @@ extension [String: Any] {
         JSONValue(ablyCocoaData: self).toAblyCocoaData
     }
 }
+
+extension ARTMessageVersion {
+    convenience init(serial: String) {
+        self.init()
+        self.serial = serial
+    }
+}
+
+extension ARTMessageAnnotations {
+    convenience init(summary: [String: Any]) {
+        self.init()
+        self.summary = summary
+    }
+}

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -288,7 +288,6 @@ struct IntegrationTests {
         #expect(rxEditedMessageFromSubscription.clientID == txEditedMessage.clientID)
         #expect(rxEditedMessageFromSubscription.version == txEditedMessage.version)
         #expect(rxEditedMessageFromSubscription.id == txEditedMessage.id)
-        #expect(rxEditedMessageFromSubscription.operation == txEditedMessage.operation)
         // Ensures text has been edited from original message
         #expect(rxEditedMessageFromSubscription.text == txEditedMessage.text)
         // Ensure headers are now null when compared to original message
@@ -313,7 +312,6 @@ struct IntegrationTests {
         #expect(rxDeletedMessageFromSubscription.clientID == txDeleteMessage.clientID)
         #expect(rxDeletedMessageFromSubscription.version == txDeleteMessage.version)
         #expect(rxDeletedMessageFromSubscription.id == txDeleteMessage.id)
-        #expect(rxDeletedMessageFromSubscription.operation == txDeleteMessage.operation)
         #expect(rxDeletedMessageFromSubscription.text.isEmpty)
         #expect(rxDeletedMessageFromSubscription.headers.isEmpty)
         #expect(rxDeletedMessageFromSubscription.metadata.isEmpty)

--- a/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
@@ -1,5 +1,6 @@
 @testable import AblyChat
 import AsyncAlgorithms
+import Foundation
 import Testing
 
 private final class MockPaginatedResult<Item: Equatable>: PaginatedResult {
@@ -26,7 +27,7 @@ private final class MockPaginatedResult<Item: Equatable>: PaginatedResult {
 
 struct MessageSubscriptionAsyncSequenceTests {
     let messages = ["First", "Second"].map { text in
-        Message(serial: "", action: .create, clientID: "", text: text, createdAt: .init(), metadata: [:], headers: [:], version: "", timestamp: nil)
+        Message(serial: "", action: .create, clientID: "", text: text, metadata: [:], headers: [:], version: .init(serial: "", timestamp: Date()), timestamp: Date())
     }
 
     @Test

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -59,13 +59,15 @@ extension MockHTTPPaginatedResponse {
         items: [
             [
                 "serial": "3446456",
-                "version": "3446456",
+                "version": [
+                    "serial": "3446456",
+                ],
                 "timestamp": 1_631_840_000_000,
                 "createdAt": 1_631_840_000_000,
                 "text": "hello",
             ],
         ],
-        statusCode: 500,
+        statusCode: 200,
         headers: [:]
     )
 
@@ -97,11 +99,12 @@ extension MockHTTPPaginatedResponse {
                 "clientId": "random",
                 "serial": "3446456",
                 "action": "message.create",
-                "createdAt": 1_730_943_049_269,
                 "text": "hello",
                 "metadata": [:],
                 "headers": [:],
-                "version": "3446456",
+                "version": [
+                    "serial": "3446456",
+                ],
                 "timestamp": 1_730_943_049_269,
             ],
             [
@@ -111,7 +114,10 @@ extension MockHTTPPaginatedResponse {
                 "text": "hello response",
                 "metadata": [:],
                 "headers": [:],
-                "version": "3446457",
+                "version": [
+                    "serial": "3446457",
+                ],
+                "timestamp": 1_730_943_051_269,
             ],
         ],
         statusCode: 200,
@@ -129,11 +135,13 @@ extension MockHTTPPaginatedResponse {
                 "clientId": "random",
                 "serial": "3446458",
                 "action": "message.create",
-                "createdAt": 1_730_943_049_269,
+                "timestamp": 1_730_943_053_269,
                 "text": "next hello",
                 "metadata": [:],
                 "headers": [:],
-                "version": "3446458",
+                "version": [
+                    "serial": "3446458",
+                ],
             ],
             [
                 "clientId": "random",
@@ -142,7 +150,10 @@ extension MockHTTPPaginatedResponse {
                 "text": "next hello response",
                 "metadata": [:],
                 "headers": [:],
-                "version": "3446459",
+                "version": [
+                    "serial": "3446459",
+                ],
+                "timestamp": 1_730_943_055_269,
             ],
         ],
         statusCode: 200,


### PR DESCRIPTION
Closes #349 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Message versioning is now structured (serial, timestamp, clientID, description, metadata).
  - Reaction summaries are stored and read via message annotations.

- Refactor
  - Chat REST API migrated to v4; endpoints updated.
  - createdAt renamed to timestamp; missing timestamps default to Unix epoch.
  - Legacy message operation handling removed; message surface uses structured version and timestamp.

- Chore
  - Ably SDK dependency bumped.

- Tests
  - Tests updated for v4 endpoints, new version/timestamp shapes, and annotation helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->