### PR TITLE
Treat warnings as errors via package manifest

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -90,10 +90,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
-      # https://forums.swift.org/t/warnings-as-errors-for-libraries-frameworks/58393/2
-      - run: swift build -Xswiftc -warnings-as-errors
+      - run: swift build
       # Disabling testing temporarily due to intermittent hangs on CI (https://github.com/ably/ably-chat-swift/issues/295)
-      #- run: swift test -Xswiftc -warnings-as-errors
+      #- run: swift test
 
   build-release-configuration-spm:
     name: SPM, `release` configuration (Xcode ${{ matrix.tooling.xcodeVersion }})
@@ -111,8 +110,7 @@ jobs:
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
-      # https://forums.swift.org/t/warnings-as-errors-for-libraries-frameworks/58393/2
-      - run: swift build -Xswiftc -warnings-as-errors --configuration release
+      - run: swift build --configuration release
 
   build-and-test-xcode:
     name: Xcode, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@
 import PackageDescription
 
 let commonSwiftSettings: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("ExistentialAny"),
 ]

--- a/Sources/BuildTool/XcodeRunner.swift
+++ b/Sources/BuildTool/XcodeRunner.swift
@@ -24,46 +24,6 @@ enum XcodeRunner {
             arguments.append(contentsOf: ["-resultBundlePath", resultBundlePath])
         }
 
-        /*
-         Note: I was previously passing SWIFT_TREAT_WARNINGS_AS_ERRORS=YES here, but am no longer able to do so, for the following reasons:
-
-         1. After adding a new package dependency, Xcode started trying to pass
-            the Swift compiler the -suppress-warnings flag when compiling one of
-            the newly-added transitive dependencies. This clashes with the
-            -warnings-as-errors flag that Xcode adds when you set
-            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES, leading to a compiler error like
-
-            > error: Conflicting options '-warnings-as-errors' and '-suppress-warnings' (in target 'InternalCollectionsUtilities' from project 'swift-collections')
-
-            It’s not clear _why_ Xcode is adding this flag (see
-            https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810),
-            but perhaps it’s because of what I mention in point 2 below.
-
-            It seems that there is no way to tell Xcode, when building your own
-            Swift package, “treat warnings as errors, but only for my package, and
-            not for its dependencies”.
-
-         2. So, I thought that I’d try making Xcode remove the
-            -suppress-warnings flag by additionally passing
-            SWIFT_SUPPRESS_WARNINGS=NO, but this also doesn’t work because it turns
-            out that one of our dependencies (swift-async-algorithms) actually does
-            have some warnings, causing the build to fail.
-
-         tl;dr: There doesn’t seem to be a way to treat warnings as errors when
-         compiling the package from Package.swift using Xcode.
-
-         It’s probably OK, though, because we also compile the package with SPM,
-         and hopefully that will flag any warnings in CI (unless there’s some
-         class of warnings I’m not aware of that only appear when compiling
-         against the tvOS or iOS SDK).
-
-         (I imagine that using .unsafeFlags(["-warnings-as-errors"]) in the
-         manifest might work, but then that’d stop other people from being able
-         to use us as a dependency. I suppose we could, in CI at least, do
-         something like modifying the manifest as part of the build process, but
-         that seems like a nuisance.)
-         */
-
         try await ProcessRunner.run(executableName: "xcodebuild", arguments: arguments)
     }
 }

--- a/Tests/AblyChatTests/DefaultRoomOccupancyTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomOccupancyTests.swift
@@ -143,8 +143,8 @@ struct DefaultRoomOccupancyTests {
         let doIt = {
             _ = try defaultOccupancy.current()
         }
-        await #expect {
-            try await doIt()
+        #expect {
+            try doIt()
         } throws: { error in
             error as? ARTErrorInfo == ARTErrorInfo(chatError: .occupancyEventsNotEnabled)
         }

--- a/Tests/AblyChatTests/JSONValueTests.swift
+++ b/Tests/AblyChatTests/JSONValueTests.swift
@@ -22,7 +22,7 @@ struct JSONValueTests {
         (ablyCocoaPresenceData: NSNumber(value: false), expectedResult: false),
         // null
         (ablyCocoaPresenceData: NSNull(), expectedResult: .null),
-    ] as[(ablyCocoaPresenceData: Sendable, expectedResult: JSONValue?)])
+    ] as[(ablyCocoaPresenceData: any Sendable, expectedResult: JSONValue?)])
     func initWithAblyCocoaPresenceData(ablyCocoaData: any Sendable, expectedResult: JSONValue?) {
         #expect(JSONValue(ablyCocoaData: ablyCocoaData) == expectedResult)
     }
@@ -94,7 +94,7 @@ struct JSONValueTests {
         (value: false, expectedResult: NSNumber(value: false)),
         // null
         (value: .null, expectedResult: NSNull()),
-    ] as[(value: JSONValue, expectedResult: Sendable)])
+    ] as[(value: JSONValue, expectedResult: any Sendable)])
     func toAblyCocoaData(value: JSONValue, expectedResult: any Sendable) throws {
         let resultAsNSObject = try #require(value.toAblyCocoaData as? NSObject)
         let expectedResultAsNSObject = try #require(expectedResult as? NSObject)

--- a/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
@@ -52,8 +52,6 @@ struct MessageSubscriptionAsyncSequenceTests {
         let subscription = MessageSubscriptionAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
 
         let result = try await subscription.getPreviousMessages(params: .init())
-        // This dance is to avoid the compiler error "Runtime support for parameterized protocol types is only available in iOS 16.0.0 or newer" — casting back to a concrete type seems to avoid this
-        let resultAsConcreteType = try #require(result as? MockPaginatedResult<Message>)
-        #expect(resultAsConcreteType === mockPaginatedResult)
+        #expect(result === mockPaginatedResult)
     }
 }


### PR DESCRIPTION
**Note: This PR is based on top of #364; please review that one first.**

This is a new feature of Swift 6.2 and greatly simplifies building the library (and means we'll now catch warnings when doing platform-specific builds via xcodebuild too, which we couldn't before).