### PR TITLE
Remove `nonisolated` everywhere

### DIFF
--- a/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
@@ -49,11 +49,11 @@ internal protocol InternalRealtimeChannelProtocol: AnyObject, Sendable {
     /// The ably-cocoa realtime channel wrapped by the proxy channel wrapped by this channel (e.g. the `ARTRealtimeChannel` that underlies the `ARTWrapperSDKProxyRealtimeChannel` that underlies this `InternalRealtimeChannelProtocol`).
     ///
     /// We need to be able to access this so that we can return it from the `channel` methods in the SDK's public API, which allow users of the SDK to access the realtime channels that the SDK uses.
-    nonisolated var proxied: Proxied { get }
+    var proxied: Proxied { get }
 
-    nonisolated var presence: Presence { get }
+    var presence: Presence { get }
 
-    nonisolated var annotations: Annotations { get }
+    var annotations: Annotations { get }
 
     func attach() async throws(InternalError)
     func detach() async throws(InternalError)

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -11,7 +11,7 @@ public protocol ChatClientProtocol: AnyObject, Sendable {
      *
      * - Returns: The rooms object.
      */
-    nonisolated var rooms: Rooms { get }
+    var rooms: Rooms { get }
 
     /**
      * Returns the underlying connection to Ably, which can be used to monitor the clients
@@ -19,7 +19,7 @@ public protocol ChatClientProtocol: AnyObject, Sendable {
      *
      * - Returns: The connection object.
      */
-    nonisolated var connection: Connection { get }
+    var connection: Connection { get }
 
     /**
      * Returns the clientId of the current client.
@@ -33,14 +33,14 @@ public protocol ChatClientProtocol: AnyObject, Sendable {
      *
      * - Returns: The Ably Realtime client.
      */
-    nonisolated var realtime: Realtime { get }
+    var realtime: Realtime { get }
 
     /**
      * Returns the resolved client options for the client, including any defaults that have been set.
      *
      * - Returns: The client options.
      */
-    nonisolated var clientOptions: ChatClientOptions { get }
+    var clientOptions: ChatClientOptions { get }
 }
 
 @MainActor
@@ -60,8 +60,8 @@ internal final class DefaultInternalRealtimeClientFactory<Underlying: ProxyRealt
  * This is the core client for Ably chat. It provides access to chat rooms.
  */
 public class ChatClient: ChatClientProtocol {
-    public nonisolated let realtime: ARTRealtime
-    public nonisolated let clientOptions: ChatClientOptions
+    public let realtime: ARTRealtime
+    public let clientOptions: ChatClientOptions
     private let _rooms: DefaultRooms<DefaultRoomFactory<InternalRealtimeClientAdapter<ARTWrapperSDKProxyRealtime>>>
     public var rooms: some Rooms<ARTRealtimeChannel> {
         _rooms
@@ -108,7 +108,7 @@ public class ChatClient: ChatClientProtocol {
         _connection = DefaultConnection(realtime: internalRealtime)
     }
 
-    public nonisolated var clientID: String {
+    public var clientID: String {
         guard let clientID = realtime.clientId else {
             fatalError("Ensure your Realtime instance is initialized with a clientId.")
         }

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -20,14 +20,14 @@ public protocol Room: AnyObject, Sendable {
      *
      * - Returns: The room identifier.
      */
-    nonisolated var name: String { get }
+    var name: String { get }
 
     /**
      * Allows you to send, subscribe-to and query messages in the room.
      *
      * - Returns: The messages instance for the room.
      */
-    nonisolated var messages: Messages { get }
+    var messages: Messages { get }
 
     /**
      * Allows you to subscribe to presence events in the room.
@@ -36,7 +36,7 @@ public protocol Room: AnyObject, Sendable {
      *
      * - Returns: The presence instance for the room.
      */
-    nonisolated var presence: Presence { get }
+    var presence: Presence { get }
 
     /**
      * Allows you to interact with room-level reactions.
@@ -45,7 +45,7 @@ public protocol Room: AnyObject, Sendable {
      *
      * - Returns: The room reactions instance for the room.
      */
-    nonisolated var reactions: Reactions { get }
+    var reactions: Reactions { get }
 
     /**
      * Allows you to interact with typing events in the room.
@@ -54,7 +54,7 @@ public protocol Room: AnyObject, Sendable {
      *
      * - Returns: The typing instance for the room.
      */
-    nonisolated var typing: Typing { get }
+    var typing: Typing { get }
 
     /**
      * Allows you to interact with occupancy metrics for the room.
@@ -63,7 +63,7 @@ public protocol Room: AnyObject, Sendable {
      *
      * - Returns: The occupancy instance for the room.
      */
-    nonisolated var occupancy: Occupancy { get }
+    var occupancy: Occupancy { get }
 
     /**
      * The current status of the room.
@@ -120,14 +120,14 @@ public protocol Room: AnyObject, Sendable {
      *
      * - Returns: A copy of the options used to create the room.
      */
-    nonisolated var options: RoomOptions { get }
+    var options: RoomOptions { get }
 
     /**
      * Get the underlying Ably realtime channel used for the room.
      *
      * - Returns: The realtime channel.
      */
-    nonisolated var channel: Channel { get }
+    var channel: Channel { get }
 }
 
 /// `AsyncSequence` variant of `Room` status changes.
@@ -239,29 +239,29 @@ internal final class DefaultRoomFactory<Realtime: InternalRealtimeClientProtocol
 }
 
 internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol, LifecycleManager: RoomLifecycleManager>: InternalRoom {
-    internal nonisolated let name: String
-    internal nonisolated let options: RoomOptions
+    internal let name: String
+    internal let options: RoomOptions
     private let chatAPI: ChatAPI
 
-    internal nonisolated let messages: DefaultMessages
-    internal nonisolated let reactions: DefaultRoomReactions
-    internal nonisolated let presence: DefaultPresence
-    internal nonisolated let occupancy: DefaultOccupancy
-    internal nonisolated let typing: DefaultTyping
+    internal let messages: DefaultMessages
+    internal let reactions: DefaultRoomReactions
+    internal let presence: DefaultPresence
+    internal let occupancy: DefaultOccupancy
+    internal let typing: DefaultTyping
 
     // Exposed for testing.
-    private nonisolated let realtime: Realtime
+    private let realtime: Realtime
 
     private let lifecycleManager: LifecycleManager
     private let internalChannel: Realtime.Channels.Channel
 
     // Note: This property only exists to satisfy the `Room` interface. Do not use this property inside this class; use `internalChannel`.
-    internal nonisolated var channel: Realtime.Channels.Channel.Proxied {
+    internal var channel: Realtime.Channels.Channel.Proxied {
         internalChannel.proxied
     }
 
     #if DEBUG
-        internal nonisolated var testsOnly_internalChannel: Realtime.Channels.Channel {
+        internal var testsOnly_internalChannel: Realtime.Channels.Channel {
             internalChannel
         }
     #endif

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -56,7 +56,7 @@ public protocol Rooms<Channel>: AnyObject, Sendable {
      *
      * - Returns: ``ClientOptions`` object.
      */
-    nonisolated var clientOptions: ChatClientOptions { get }
+    var clientOptions: ChatClientOptions { get }
 }
 
 public extension Rooms {
@@ -67,16 +67,16 @@ public extension Rooms {
 }
 
 internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
-    private nonisolated let realtime: RoomFactory.Realtime
+    private let realtime: RoomFactory.Realtime
     private let chatAPI: ChatAPI
 
     #if DEBUG
-        internal nonisolated var testsOnly_realtime: RoomFactory.Realtime {
+        internal var testsOnly_realtime: RoomFactory.Realtime {
             realtime
         }
     #endif
 
-    internal nonisolated let clientOptions: ChatClientOptions
+    internal let clientOptions: ChatClientOptions
 
     private let logger: any InternalLogger
     private let roomFactory: RoomFactory
@@ -108,7 +108,7 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
         case created(room: RoomFactory.Room)
 
         /// The room options that correspond to this room map entry (either the options that were passed to the pending room fetch request, or the options of the created room).
-        var roomOptions: RoomOptions {
+        @MainActor var roomOptions: RoomOptions {
             switch self {
             case let .requestAwaitingRelease(_, requestedOptions: options, _, _):
                 options


### PR DESCRIPTION
I think that most of this usage dates back to before we isolated everything to the main actor in fc83fc1. Let's get rid of it, to preserve the flexibility to do things like initialise properties lazily.