### PR TITLE
Set up linter to catch missing docs for public API

### DIFF
--- a/Sources/AblyChat/.swiftlint.yml
+++ b/Sources/AblyChat/.swiftlint.yml
@@ -1,3 +1,12 @@
 opt_in_rules:
   # Opt-in rules of type "idiomatic" that we’ve decided we want:
   - explicit_acl
+
+  # Opt-in rules of type "lint" that we’ve decided we want:
+  - missing_docs
+
+missing_docs:
+  # Not sure why we'd want to exclude extensions, so turn this off.
+  excludes_extensions: false
+  # Without this, it doesn't take any of our protocols into account
+  excludes_inherited_types: false

--- a/Sources/AblyChat/BufferingPolicy.swift
+++ b/Sources/AblyChat/BufferingPolicy.swift
@@ -3,8 +3,11 @@
  * (This is the same as `AsyncStream<Element>.Continuation.BufferingPolicy` but with the generic type parameter `Element` removed.)
  */
 public enum BufferingPolicy: Sendable {
+    // swiftlint:disable:next missing_docs
     case unbounded
+    // swiftlint:disable:next missing_docs
     case bufferingOldest(Int)
+    // swiftlint:disable:next missing_docs
     case bufferingNewest(Int)
 
     internal func asAsyncStreamBufferingPolicy<Element>() -> AsyncStream<Element>.Continuation.BufferingPolicy {

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -1,9 +1,17 @@
 import Ably
 
+// This disable of attributes can be removed once missing_docs fixed here
+// swiftlint:disable attributes
 @MainActor
+// swiftlint:disable:next missing_docs
 public protocol ChatClientProtocol: AnyObject, Sendable {
+    // swiftlint:enable attributes
+
+    // swiftlint:disable:next missing_docs
     associatedtype Realtime
+    // swiftlint:disable:next missing_docs
     associatedtype Connection: AblyChat.Connection
+    // swiftlint:disable:next missing_docs
     associatedtype Rooms: AblyChat.Rooms
 
     /**
@@ -60,9 +68,12 @@ internal final class DefaultInternalRealtimeClientFactory<Underlying: ProxyRealt
  * This is the core client for Ably chat. It provides access to chat rooms.
  */
 public class ChatClient: ChatClientProtocol {
+    // swiftlint:disable:next missing_docs
     public let realtime: ARTRealtime
+    // swiftlint:disable:next missing_docs
     public let clientOptions: ChatClientOptions
     private let _rooms: DefaultRooms<DefaultRoomFactory<InternalRealtimeClientAdapter<ARTWrapperSDKProxyRealtime>>>
+    // swiftlint:disable:next missing_docs
     public var rooms: some Rooms<ARTRealtimeChannel> {
         _rooms
     }
@@ -72,6 +83,7 @@ public class ChatClient: ChatClientProtocol {
     // (CHA-CS1) Every chat client has a status, which describes the current status of the connection.
     // (CHA-CS4) The chat client must allow its connection status to be observed by clients.
     private let _connection: DefaultConnection
+    // swiftlint:disable:next missing_docs
     public var connection: some Connection {
         _connection
     }
@@ -108,6 +120,7 @@ public class ChatClient: ChatClientProtocol {
         _connection = DefaultConnection(realtime: internalRealtime)
     }
 
+    // swiftlint:disable:next missing_docs
     public var clientID: String {
         guard let clientID = realtime.clientId else {
             fatalError("Ensure your Realtime instance is initialized with a clientId.")
@@ -134,6 +147,7 @@ public struct ChatClientOptions: Sendable {
      */
     public var logLevel: LogLevel? = .error
 
+    // swiftlint:disable:next missing_docs
     public init(logHandler: LogHandler? = nil, logLevel: LogLevel? = .error) {
         self.logHandler = logHandler
         self.logLevel = logLevel

--- a/Sources/AblyChat/Connection.swift
+++ b/Sources/AblyChat/Connection.swift
@@ -5,6 +5,7 @@ import Ably
  */
 @MainActor
 public protocol Connection: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype StatusSubscription: AblyChat.StatusSubscription
 
     /**
@@ -154,6 +155,9 @@ public struct ConnectionStatusChange: Sendable {
      */
     public var retryIn: TimeInterval
 
+    /// Memberwise initializer to create a `ConnectionStatusChange`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(current: ConnectionStatus, previous: ConnectionStatus, error: ARTErrorInfo? = nil, retryIn: TimeInterval) {
         self.current = current
         self.previous = previous

--- a/Sources/AblyChat/DiscontinuityEvent.swift
+++ b/Sources/AblyChat/DiscontinuityEvent.swift
@@ -1,9 +1,13 @@
 import Ably
 
+// swiftlint:disable:next missing_docs
 public struct DiscontinuityEvent: Sendable {
     /// The error associated with this discontinuity.
     public var error: ARTErrorInfo
 
+    /// Memberwise initializer to create a `DiscontinuityEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(error: ARTErrorInfo) {
         self.error = error
     }

--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -36,6 +36,7 @@ public enum ErrorCode: Int {
      */
     case roomReleasedBeforeOperationCompleted = 102_106
 
+    // swiftlint:disable:next missing_docs
     case roomInInvalidState = 102_107
 
     /**

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -8,7 +8,9 @@ public enum MessageAction: Sendable {
      * Action applied to a new message.
      */
     case create
+    // swiftlint:disable:next missing_docs
     case update
+    // swiftlint:disable:next missing_docs
     case delete
 
     internal static func fromRealtimeAction(_ action: ARTMessageAction) -> Self? {
@@ -79,7 +81,9 @@ internal enum OccupancyEvents: String {
 
 /// Enum representing the typing event types.
 public enum TypingEventType: Sendable {
+    // swiftlint:disable:next missing_docs
     case started
+    // swiftlint:disable:next missing_docs
     case stopped
 
     internal var rawValue: String {
@@ -94,6 +98,7 @@ public enum TypingEventType: Sendable {
 
 /// Enum representing the typing set event types.
 public enum TypingSetEventType: Sendable {
+    // swiftlint:disable:next missing_docs
     case setChanged
 
     internal var rawValue: String {

--- a/Sources/AblyChat/Headers.swift
+++ b/Sources/AblyChat/Headers.swift
@@ -2,9 +2,13 @@ import Ably
 
 /// A value that can be used in ``Headers``. It is the same as ``JSONValue`` except it does not have the `object` or `array` cases.
 public enum HeadersValue: Sendable, Equatable {
+    // swiftlint:disable:next missing_docs
     case string(String)
+    // swiftlint:disable:next missing_docs
     case number(Double)
+    // swiftlint:disable:next missing_docs
     case bool(Bool)
+    // swiftlint:disable:next missing_docs
     case null
 
     // MARK: - Convenience getters for associated values
@@ -47,24 +51,28 @@ public enum HeadersValue: Sendable, Equatable {
 }
 
 extension HeadersValue: ExpressibleByStringLiteral {
+    // swiftlint:disable:next missing_docs
     public init(stringLiteral value: String) {
         self = .string(value)
     }
 }
 
 extension HeadersValue: ExpressibleByIntegerLiteral {
+    // swiftlint:disable:next missing_docs
     public init(integerLiteral value: Int) {
         self = .number(Double(value))
     }
 }
 
 extension HeadersValue: ExpressibleByFloatLiteral {
+    // swiftlint:disable:next missing_docs
     public init(floatLiteral value: Double) {
         self = .number(value)
     }
 }
 
 extension HeadersValue: ExpressibleByBooleanLiteral {
+    // swiftlint:disable:next missing_docs
     public init(booleanLiteral value: Bool) {
         self = .bool(value)
     }

--- a/Sources/AblyChat/JSONValue.swift
+++ b/Sources/AblyChat/JSONValue.swift
@@ -29,11 +29,17 @@ public typealias JSONObject = [String: JSONValue]
 ///
 /// > Note: To write a `JSONValue` that corresponds to the `null` JSON value, you must explicitly write `.null`. `JSONValue` deliberately does not implement the `ExpressibleByNilLiteral` protocol in order to avoid confusion between a value of type `JSONValue?` and a `JSONValue` with case `.null`.
 public indirect enum JSONValue: Sendable, Equatable {
+    // swiftlint:disable:next missing_docs
     case object(JSONObject)
+    // swiftlint:disable:next missing_docs
     case array([JSONValue])
+    // swiftlint:disable:next missing_docs
     case string(String)
+    // swiftlint:disable:next missing_docs
     case number(Double)
+    // swiftlint:disable:next missing_docs
     case bool(Bool)
+    // swiftlint:disable:next missing_docs
     case null
 
     // MARK: - Convenience getters for associated values
@@ -94,36 +100,42 @@ public indirect enum JSONValue: Sendable, Equatable {
 }
 
 extension JSONValue: ExpressibleByDictionaryLiteral {
+    // swiftlint:disable:next missing_docs
     public init(dictionaryLiteral elements: (String, JSONValue)...) {
         self = .object(.init(uniqueKeysWithValues: elements))
     }
 }
 
 extension JSONValue: ExpressibleByArrayLiteral {
+    // swiftlint:disable:next missing_docs
     public init(arrayLiteral elements: JSONValue...) {
         self = .array(elements)
     }
 }
 
 extension JSONValue: ExpressibleByStringLiteral {
+    // swiftlint:disable:next missing_docs
     public init(stringLiteral value: String) {
         self = .string(value)
     }
 }
 
 extension JSONValue: ExpressibleByIntegerLiteral {
+    // swiftlint:disable:next missing_docs
     public init(integerLiteral value: Int) {
         self = .number(Double(value))
     }
 }
 
 extension JSONValue: ExpressibleByFloatLiteral {
+    // swiftlint:disable:next missing_docs
     public init(floatLiteral value: Double) {
         self = .number(value)
     }
 }
 
 extension JSONValue: ExpressibleByBooleanLiteral {
+    // swiftlint:disable:next missing_docs
     public init(booleanLiteral value: Bool) {
         self = .bool(value)
     }

--- a/Sources/AblyChat/Logging.swift
+++ b/Sources/AblyChat/Logging.swift
@@ -1,5 +1,6 @@
 import os
 
+// swiftlint:disable:next missing_docs
 public struct LogHandler: Sendable {
     fileprivate let simple: any Simple
 
@@ -33,10 +34,15 @@ public struct LogHandler: Sendable {
  * Represents the different levels of logging that can be used.
  */
 public enum LogLevel: Sendable, Comparable {
+    // swiftlint:disable:next missing_docs
     case trace
+    // swiftlint:disable:next missing_docs
     case debug
+    // swiftlint:disable:next missing_docs
     case info
+    // swiftlint:disable:next missing_docs
     case warn
+    // swiftlint:disable:next missing_docs
     case error
 }
 

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -84,6 +84,9 @@ public struct Message: Sendable, Equatable {
      */
     public var reactions: MessageReactionSummary?
 
+    /// Memberwise initializer to create a `Message`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(serial: String, action: MessageAction, clientID: String, text: String, metadata: MessageMetadata, headers: MessageHeaders, version: MessageVersion, timestamp: Date, reactions: MessageReactionSummary? = nil) {
         self.serial = serial
         self.action = action
@@ -124,6 +127,7 @@ public struct Message: Sendable, Equatable {
     }
 }
 
+/// Represents the version information for a message.
 public struct MessageVersion: Sendable, Equatable {
     /**
      * A unique identifier for the latest version of this message.
@@ -150,6 +154,9 @@ public struct MessageVersion: Sendable, Equatable {
      */
     public var metadata: MessageMetadata?
 
+    /// Memberwise initializer to create a `MessageVersion`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(serial: String, timestamp: Date, clientID: String? = nil, description: String? = nil, metadata: MessageMetadata? = nil) {
         self.serial = serial
         self.timestamp = timestamp
@@ -204,6 +211,7 @@ extension MessageVersion {
     }
 }
 
+// swiftlint:disable:next missing_docs
 public extension Message {
     /**
      * Creates a new message instance with the event applied.

--- a/Sources/AblyChat/MessageReaction.swift
+++ b/Sources/AblyChat/MessageReaction.swift
@@ -75,6 +75,9 @@ public struct MessageReaction: Sendable {
      */
     public var isSelf: Bool
 
+    /// Memberwise initializer to create a `MessageReaction`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: MessageReactionType, name: String, messageSerial: String, count: Int? = nil, clientID: String, isSelf: Bool) {
         self.type = type
         self.name = name
@@ -176,6 +179,7 @@ public struct MessageReactionSummary: Sendable, Equatable {
          */
         public var clipped: Bool // TM7c1c
 
+        // swiftlint:disable:next missing_docs
         public init(total: Int, clientIDs: [String], clipped: Bool) {
             self.total = total
             self.clientIDs = clientIDs
@@ -214,6 +218,7 @@ public struct MessageReactionSummary: Sendable, Equatable {
          */
         public var totalClientIDs: Int // TM7d1e
 
+        // swiftlint:disable:next missing_docs
         public init(total: Int, clientIDs: [String: Int], totalUnidentified: Int, clipped: Bool, totalClientIDs: Int) {
             self.total = total
             self.clientIDs = clientIDs
@@ -243,6 +248,9 @@ public struct MessageReactionSummary: Sendable, Equatable {
      */
     public var multiple: [String: ClientIDCounts]
 
+    /// Memberwise initializer to create a `MessageReactionSummary`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(messageSerial: String, unique: [String: MessageReactionSummary.ClientIDList], distinct: [String: MessageReactionSummary.ClientIDList], multiple: [String: MessageReactionSummary.ClientIDCounts]) {
         self.messageSerial = messageSerial
         self.unique = unique
@@ -266,6 +274,9 @@ public struct MessageReactionSummaryEvent: Sendable, Equatable {
      */
     public var summary: MessageReactionSummary
 
+    /// Memberwise initializer to create a `MessageReactionSummaryEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: MessageReactionEvent, summary: MessageReactionSummary) {
         self.type = type
         self.summary = summary
@@ -291,6 +302,9 @@ public struct MessageReactionRawEvent: Sendable {
      */
     public var reaction: MessageReaction
 
+    /// Memberwise initializer to create a `MessageReactionRawEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: MessageReactionEvent, timestamp: Date? = nil, reaction: MessageReaction) {
         self.type = type
         self.timestamp = timestamp

--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -7,6 +7,7 @@ import Ably
  */
 @MainActor
 public protocol MessageReactions: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Subscription: AblyChat.Subscription
 
     /**
@@ -136,6 +137,9 @@ public struct SendMessageReactionParams: Sendable {
      */
     public var count: Int?
 
+    /// Memberwise initializer to create a `SendMessageReactionParams`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(name: String, type: MessageReactionType? = nil, count: Int? = nil) {
         self.name = name
         self.type = type
@@ -158,6 +162,9 @@ public struct DeleteMessageReactionParams: Sendable {
      */
     public var name: String?
 
+    /// Memberwise initializer to create a `DeleteMessageReactionParams`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(name: String? = nil, type: MessageReactionType? = nil) {
         self.name = name
         self.type = type

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -8,8 +8,11 @@ import Ably
  */
 @MainActor
 public protocol Messages: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Reactions: MessageReactions
+    // swiftlint:disable:next missing_docs
     associatedtype SubscribeResponse: MessageSubscriptionResponse
+    // swiftlint:disable:next missing_docs
     associatedtype HistoryResult: PaginatedResult<Message>
 
     /**
@@ -83,6 +86,7 @@ public protocol Messages: AnyObject, Sendable {
     var reactions: Reactions { get }
 }
 
+// swiftlint:disable:next missing_docs
 public extension Messages {
     /**
      * Subscribe to new messages in this chat room.
@@ -161,6 +165,7 @@ public struct SendMessageParams: Sendable {
      */
     public var headers: MessageHeaders?
 
+    // swiftlint:disable:next missing_docs
     public init(text: String, metadata: MessageMetadata? = nil, headers: MessageHeaders? = nil) {
         self.text = text
         self.metadata = metadata
@@ -197,6 +202,7 @@ public struct UpdateMessageParams: Sendable {
      */
     public var metadata: OperationMetadata?
 
+    // swiftlint:disable:next missing_docs
     public init(message: SendMessageParams, description: String? = nil, metadata: OperationMetadata? = nil) {
         self.message = message
         self.description = description
@@ -208,10 +214,13 @@ public struct UpdateMessageParams: Sendable {
  * Params for deleting a message.
  */
 public struct DeleteMessageParams: Sendable {
+    // swiftlint:disable:next missing_docs
     public var description: String?
 
+    // swiftlint:disable:next missing_docs
     public var metadata: OperationMetadata?
 
+    // swiftlint:disable:next missing_docs
     public init(description: String? = nil, metadata: OperationMetadata? = nil) {
         self.description = description
         self.metadata = metadata
@@ -222,8 +231,11 @@ public struct DeleteMessageParams: Sendable {
  * Options for querying messages in a chat room.
  */
 public struct QueryOptions: Sendable {
+    // swiftlint:disable:next missing_docs
     public enum OrderBy: Sendable {
+        // swiftlint:disable:next missing_docs
         case oldestFirst
+        // swiftlint:disable:next missing_docs
         case newestFirst
     }
 
@@ -261,6 +273,7 @@ public struct QueryOptions: Sendable {
     // (CHA-M5g) The subscribers subscription point must be additionally specified (internally, by us) in the fromSerial query parameter.
     internal var fromSerial: String?
 
+    // swiftlint:disable:next missing_docs
     public init(start: Date? = nil, end: Date? = nil, limit: Int? = nil, orderBy: QueryOptions.OrderBy? = nil) {
         self.start = start
         self.end = end
@@ -304,16 +317,24 @@ internal extension QueryOptions {
 
 /// Event type for chat message subscription.
 public enum ChatMessageEventType: Sendable {
+    // swiftlint:disable:next missing_docs
     case created
+    // swiftlint:disable:next missing_docs
     case updated
+    // swiftlint:disable:next missing_docs
     case deleted
 }
 
 /// Event emitted by message subscriptions, containing the type and the message.
 public struct ChatMessageEvent: Sendable {
+    // swiftlint:disable:next missing_docs
     public var type: ChatMessageEventType
+    // swiftlint:disable:next missing_docs
     public var message: Message
 
+    /// Memberwise initializer to create a `ChatMessageEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: ChatMessageEventType, message: Message) {
         self.type = type
         self.message = message
@@ -336,6 +357,7 @@ public struct ChatMessageEvent: Sendable {
 ///
 /// You should only iterate over a given `MessageSubscriptionAsyncSequence` once; the results of iterating more than once are undefined.
 public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResult<Message>>: Sendable, AsyncSequence {
+    // swiftlint:disable:next missing_docs
     public typealias Element = ChatMessageEvent
 
     private let subscription: SubscriptionAsyncSequence<Element>
@@ -353,6 +375,7 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
     }
 
     // used for testing
+    // swiftlint:disable:next missing_docs
     public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockGetPreviousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> HistoryResult) where Underlying.Element == Element {
         subscription = .init(mockAsyncSequence: mockAsyncSequence)
         getPreviousMessages = mockGetPreviousMessages
@@ -367,10 +390,12 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
         subscription.addTerminationHandler(onTermination)
     }
 
+    // swiftlint:disable:next missing_docs
     public func getPreviousMessages(params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult {
         try await getPreviousMessages(params)
     }
 
+    // swiftlint:disable:next missing_docs
     public struct AsyncIterator: AsyncIteratorProtocol {
         private var subscriptionIterator: SubscriptionAsyncSequence<Element>.AsyncIterator
 
@@ -378,11 +403,13 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
             self.subscriptionIterator = subscriptionIterator
         }
 
+        // swiftlint:disable:next missing_docs
         public mutating func next() async -> Element? {
             await subscriptionIterator.next()
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func makeAsyncIterator() -> AsyncIterator {
         .init(subscriptionIterator: subscription.makeAsyncIterator())
     }

--- a/Sources/AblyChat/Occupancy.swift
+++ b/Sources/AblyChat/Occupancy.swift
@@ -8,6 +8,7 @@ import Ably
  */
 @MainActor
 public protocol Occupancy: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Subscription: AblyChat.Subscription
 
     /**
@@ -88,21 +89,32 @@ public struct OccupancyData: Sendable {
      */
     public var presenceMembers: Int
 
+    /// Memberwise initializer to create a `OccupancyData`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(connections: Int, presenceMembers: Int) {
         self.connections = connections
         self.presenceMembers = presenceMembers
     }
 }
 
+// swiftlint:disable:next missing_docs
 public enum OccupancyEventType: Sendable {
+    // swiftlint:disable:next missing_docs
     case updated
 }
 
 // (CHA-O2) The occupancy event format is shown here (https://sdk.ably.com/builds/ably/specification/main/chat-features/#chat-structs-occupancy-event)
+// swiftlint:disable:next missing_docs
 public struct OccupancyEvent: Sendable {
+    // swiftlint:disable:next missing_docs
     public var type: OccupancyEventType
+    // swiftlint:disable:next missing_docs
     public var occupancy: OccupancyData
 
+    /// Memberwise initializer to create a `OccupancyEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: OccupancyEventType, occupancy: OccupancyData) {
         self.type = type
         self.occupancy = occupancy

--- a/Sources/AblyChat/PaginatedResult.swift
+++ b/Sources/AblyChat/PaginatedResult.swift
@@ -1,16 +1,28 @@
 import Ably
 
+// This disable of attributes can be removed once missing_docs fixed here
+// swiftlint:disable attributes
 @MainActor
+// swiftlint:disable:next missing_docs
 public protocol PaginatedResult<Item>: AnyObject, Sendable {
+    // swiftlint:enable attributes
+
+    // swiftlint:disable:next missing_docs
     associatedtype Item
 
+    // swiftlint:disable:next missing_docs
     var items: [Item] { get }
+    // swiftlint:disable:next missing_docs
     var hasNext: Bool { get }
+    // swiftlint:disable:next missing_docs
     var isLast: Bool { get }
     // TODO: (https://github.com/ably-labs/ably-chat-swift/issues/11): consider how to avoid the need for an unwrap
     // Note that there seems to be a compiler bug (https://github.com/swiftlang/swift/issues/79992) that means that the compiler does not enforce the access level of the error type for property getters. I accidentally originally wrote these as throws(InternalError), which the compiler should have rejected since InternalError is internal and this protocol is public, but it did not reject it and this mistake was only noticed in code review.
+    // swiftlint:disable:next missing_docs
     var next: Self? { get async throws(ARTErrorInfo) }
+    // swiftlint:disable:next missing_docs
     var first: Self { get async throws(ARTErrorInfo) }
+    // swiftlint:disable:next missing_docs
     var current: Self { get async throws(ARTErrorInfo) }
 }
 

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -1,5 +1,6 @@
 import Ably
 
+// swiftlint:disable:next missing_docs
 public typealias PresenceData = JSONObject
 
 /**
@@ -10,6 +11,7 @@ public typealias PresenceData = JSONObject
  */
 @MainActor
 public protocol Presence: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Subscription: AblyChat.Subscription
 
     /**
@@ -124,6 +126,7 @@ public protocol Presence: AnyObject, Sendable {
     func leave() async throws(ARTErrorInfo)
 }
 
+// swiftlint:disable:next missing_docs
 public extension Presence {
     /**
      * Subscribes a given listener to a particular presence event in the chat room.
@@ -194,6 +197,9 @@ public extension Presence {
  * Type for PresenceMember
  */
 public struct PresenceMember: Sendable {
+    /// Memberwise initializer to create a `PresenceMember`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(clientID: String, data: PresenceData?, extras: [String: JSONValue]?, updatedAt: Date) {
         self.clientID = clientID
         self.data = data
@@ -216,6 +222,7 @@ public struct PresenceMember: Sendable {
      * The extras associated with the presence member.
      */
     public var extras: [String: JSONValue]?
+    // swiftlint:disable:next missing_docs
     public var updatedAt: Date
 }
 
@@ -271,6 +278,9 @@ public struct PresenceEvent: Sendable {
      */
     public var member: PresenceMember
 
+    /// Memberwise initializer to create a `PresenceEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: PresenceEventType, member: PresenceMember) {
         self.type = type
         self.member = member
@@ -288,6 +298,7 @@ public struct PresenceParams: Sendable {
     /// Sets whether to wait for a full presence set synchronization between Ably and the clients on the room to complete before returning the results. Synchronization begins as soon as the room is ``RoomStatus/attached``. When set to `true` the results will be returned as soon as the sync is complete. When set to `false` the current list of members will be returned without the sync completing. The default is `true`.
     public var waitForSync = true
 
+    // swiftlint:disable:next missing_docs
     public init(clientID: String? = nil, connectionID: String? = nil, waitForSync: Bool = true) {
         self.clientID = clientID
         self.connectionID = connectionID

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -5,14 +5,21 @@ import Ably
  */
 @MainActor
 public protocol Room: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Channel
 
+    // swiftlint:disable:next missing_docs
     associatedtype Messages: AblyChat.Messages
+    // swiftlint:disable:next missing_docs
     associatedtype Presence: AblyChat.Presence
+    // swiftlint:disable:next missing_docs
     associatedtype Reactions: AblyChat.RoomReactions
+    // swiftlint:disable:next missing_docs
     associatedtype Typing: AblyChat.Typing
+    // swiftlint:disable:next missing_docs
     associatedtype Occupancy: AblyChat.Occupancy
 
+    // swiftlint:disable:next missing_docs
     associatedtype StatusSubscription: AblyChat.StatusSubscription
 
     /**
@@ -209,6 +216,9 @@ public struct RoomStatusChange: Sendable {
      */
     public var previous: RoomStatus
 
+    /// Memberwise initializer to create a `RoomStatusChange`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(current: RoomStatus, previous: RoomStatus) {
         self.current = current
         self.previous = previous
@@ -358,6 +368,7 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol, LifecycleMa
         return realtime.channels.get("\(roomName)::$chat", options: channelOptions)
     }
 
+    // swiftlint:disable:next missing_docs
     public func attach() async throws(ARTErrorInfo) {
         do {
             try await lifecycleManager.performAttachOperation()
@@ -366,6 +377,7 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol, LifecycleMa
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func detach() async throws(ARTErrorInfo) {
         do {
             try await lifecycleManager.performDetachOperation()

--- a/Sources/AblyChat/RoomOptions.swift
+++ b/Sources/AblyChat/RoomOptions.swift
@@ -29,6 +29,7 @@ public struct RoomOptions: Sendable {
      */
     public var messages = MessagesOptions()
 
+    // swiftlint:disable:next missing_docs
     public init(messages: MessagesOptions = MessagesOptions(), presence: PresenceOptions = PresenceOptions(), typing: TypingOptions = TypingOptions(), reactions: RoomReactionsOptions = RoomReactionsOptions(), occupancy: OccupancyOptions = OccupancyOptions()) {
         self.messages = messages
         self.presence = presence
@@ -51,6 +52,7 @@ public struct PresenceOptions: Sendable {
      */
     public var enableEvents = true
 
+    // swiftlint:disable:next missing_docs
     public init(enableEvents: Bool = true) {
         self.enableEvents = enableEvents
     }
@@ -80,6 +82,7 @@ public struct MessagesOptions: Sendable {
      */
     public var defaultMessageReactionType = MessageReactionType.distinct
 
+    // swiftlint:disable:next missing_docs
     public init(rawMessageReactions: Bool = false, defaultMessageReactionType: MessageReactionType = .distinct) {
         self.rawMessageReactions = rawMessageReactions
         self.defaultMessageReactionType = defaultMessageReactionType
@@ -102,6 +105,7 @@ public struct TypingOptions: Sendable {
      */
     public var heartbeatThrottle: TimeInterval = 10
 
+    // swiftlint:disable:next missing_docs
     public init(heartbeatThrottle: TimeInterval = 10) {
         self.heartbeatThrottle = heartbeatThrottle
     }
@@ -111,6 +115,7 @@ public struct TypingOptions: Sendable {
  * Represents the reactions options for a chat room.
  */
 public struct RoomReactionsOptions: Sendable {
+    // swiftlint:disable:next missing_docs
     public init() {}
 }
 
@@ -127,6 +132,7 @@ public struct OccupancyOptions: Sendable {
      */
     public var enableEvents = false
 
+    // swiftlint:disable:next missing_docs
     public init(enableEvents: Bool = false) {
         self.enableEvents = enableEvents
     }

--- a/Sources/AblyChat/RoomReaction.swift
+++ b/Sources/AblyChat/RoomReaction.swift
@@ -46,6 +46,9 @@ public struct RoomReaction: Sendable {
      */
     public var isSelf: Bool
 
+    /// Memberwise initializer to create a `RoomReaction`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(name: String, metadata: ReactionMetadata, headers: ReactionHeaders, createdAt: Date, clientID: String, isSelf: Bool) {
         self.name = name
         self.metadata = metadata

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -7,6 +7,7 @@ import Ably
  */
 @MainActor
 public protocol RoomReactions: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Subscription: AblyChat.Subscription
 
     /**
@@ -100,6 +101,9 @@ public struct SendReactionParams: Sendable {
      */
     public var headers: ReactionHeaders?
 
+    /// Memberwise initializer to create a `SendReactionParams`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(name: String, metadata: ReactionMetadata? = nil, headers: ReactionHeaders? = nil) {
         self.name = name
         self.metadata = metadata
@@ -109,13 +113,20 @@ public struct SendReactionParams: Sendable {
 
 /// Event type for room reaction subscription.
 public enum RoomReactionEventType: Sendable {
+    // swiftlint:disable:next missing_docs
     case reaction
 }
 
 /// Event emitted by room reaction subscriptions, containing the type and the reaction.
 public struct RoomReactionEvent: Sendable {
+    // swiftlint:disable:next missing_docs
     public var type: RoomReactionEventType
+    // swiftlint:disable:next missing_docs
     public var reaction: RoomReaction
+
+    /// Memberwise initializer to create a `RoomReactionEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: RoomReactionEventType = .reaction, reaction: RoomReaction) {
         self.type = type
         self.reaction = reaction

--- a/Sources/AblyChat/RoomStatus.swift
+++ b/Sources/AblyChat/RoomStatus.swift
@@ -75,6 +75,7 @@ public enum RoomStatus: Sendable {
     // 1. testing (e.g.  `#expect(status.isFailed)`)
     // 2. testing that a status does _not_ have a particular case (e.g. if !status.isFailed), which a `case` statement cannot succinctly express
 
+    // swiftlint:disable:next missing_docs
     public var isAttaching: Bool {
         if case .attaching = self {
             true
@@ -83,6 +84,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isAttached: Bool {
         if case .attached = self {
             true
@@ -91,6 +93,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isDetaching: Bool {
         if case .detaching = self {
             true
@@ -99,6 +102,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isDetached: Bool {
         if case .detached = self {
             true
@@ -107,6 +111,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isSuspended: Bool {
         if case .suspended = self {
             true
@@ -115,6 +120,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isFailed: Bool {
         if case .failed = self {
             true
@@ -123,6 +129,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isReleasing: Bool {
         if case .releasing = self {
             true
@@ -131,6 +138,7 @@ public enum RoomStatus: Sendable {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public var isReleased: Bool {
         if case .released = self {
             true

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -5,7 +5,9 @@ import Ably
  */
 @MainActor
 public protocol Rooms<Channel>: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Channel
+    // swiftlint:disable:next missing_docs
     associatedtype Room: AblyChat.Room where Room.Channel == Channel
 
     /**
@@ -59,7 +61,9 @@ public protocol Rooms<Channel>: AnyObject, Sendable {
     var clientOptions: ChatClientOptions { get }
 }
 
+// swiftlint:disable:next missing_docs
 public extension Rooms {
+    // swiftlint:disable:next missing_docs
     func get(name: String) async throws(ARTErrorInfo) -> Room {
         // CHA-RC4a
         try await get(name: name, options: .init())

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -34,6 +34,7 @@ public protocol StatusSubscription: Sendable {
  */
 @MainActor
 public protocol MessageSubscriptionResponse: Subscription, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype HistoryResult: PaginatedResult<Message>
 
     /**

--- a/Sources/AblyChat/SubscriptionAsyncSequence.swift
+++ b/Sources/AblyChat/SubscriptionAsyncSequence.swift
@@ -60,6 +60,7 @@ public final class SubscriptionAsyncSequence<Element: Sendable>: Sendable, Async
     }
 
     // This is a workaround for the fact that, as mentioned above, `Subscription` is a struct when I would have liked it to be a protocol. It allows people mocking our SDK to create a `Subscription` so that they can return it from their mocks. The intention of this initializer is that if you use it, then the created `Subscription` will just replay the sequence that you pass it. It is a programmer error to pass a throwing AsyncSequence.
+    // swiftlint:disable:next missing_docs
     public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying) where Underlying.Element == Element {
         mode = .mockAsyncSequence(.init(asyncSequence: mockAsyncSequence))
     }
@@ -111,6 +112,7 @@ public final class SubscriptionAsyncSequence<Element: Sendable>: Sendable, Async
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public struct AsyncIterator: AsyncIteratorProtocol {
         fileprivate enum Mode {
             case `default`(iterator: AsyncStream<Element>.AsyncIterator)
@@ -136,11 +138,13 @@ public final class SubscriptionAsyncSequence<Element: Sendable>: Sendable, Async
             self.mode = mode
         }
 
+        // swiftlint:disable:next missing_docs
         public mutating func next() async -> Element? {
             await mode.next()
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func makeAsyncIterator() -> AsyncIterator {
         let iteratorMode: AsyncIterator.Mode = switch mode {
         case let .default(stream: stream, continuation: _):

--- a/Sources/AblyChat/Typing.swift
+++ b/Sources/AblyChat/Typing.swift
@@ -8,6 +8,7 @@ import Ably
  */
 @MainActor
 public protocol Typing: AnyObject, Sendable {
+    // swiftlint:disable:next missing_docs
     associatedtype Subscription: AblyChat.Subscription
 
     /**
@@ -86,6 +87,7 @@ public extension Typing {
  * Represents a typing event.
  */
 public struct TypingSetEvent: Sendable {
+    // swiftlint:disable:next missing_docs
     public var type: TypingSetEventType
 
     /**
@@ -98,16 +100,25 @@ public struct TypingSetEvent: Sendable {
       */
     public var change: Change
 
+    /// Memberwise initializer to create a `TypingSetEvent`.
+    ///
+    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
     public init(type: TypingSetEventType, currentlyTyping: Set<String>, change: Change) {
         self.type = type
         self.currentlyTyping = currentlyTyping
         self.change = change
     }
 
+    // swiftlint:disable:next missing_docs
     public struct Change: Sendable {
+        // swiftlint:disable:next missing_docs
         public var clientID: String
+        // swiftlint:disable:next missing_docs
         public var type: TypingEventType
 
+        /// Memberwise initializer to create a `Change`.
+        ///
+        /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
         public init(clientID: String, type: TypingEventType) {
             self.clientID = clientID
             self.type = type


### PR DESCRIPTION
I've added documentation for the trivial memberwise initializers; the rest we'll do in #377.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscribe helpers with buffering for messages and presence, plus ability to fetch previous messages.
  * Message event types: created, updated, deleted; apply reaction summaries to messages.
  * New buffering policies to keep oldest/newest with limits.
  * Pagination protocol for navigating paged results.
  * Literal/JSON/header convenience support (strings, numbers, bools, null, arrays, objects).
  * Expanded public initializers and types for messages, reactions, typing, presence, occupancy, rooms, and client surface.
  * Rooms: convenience get(name:) overload.
  * Added mock-friendly subscription replay initializer and iterator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->