### PR TITLE
Add primary associated type to `Room`

### DIFF
--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -4,7 +4,7 @@ import Ably
  * Represents a chat room.
  */
 @MainActor
-public protocol Room: AnyObject, Sendable {
+public protocol Room<Channel>: AnyObject, Sendable {
     // swiftlint:disable:next missing_docs
     associatedtype Channel
 


### PR DESCRIPTION
Didn't do this in ccefe49 because I thought we'd be able to use `ChatClient.Rooms.Room` as a type, but it appears that's not allowed. So enable the use of `Room` existentials that preserve the channel's static type information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made the chat room abstraction generic to strengthen type safety; this is a public API change and may require minor adjustments in integrations that use rooms and channels.

* **Tests**
  * Expanded test coverage around type handling and use of existentials to validate behavior when working with rooms and channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->