### PR TITLE
Make message subscription async sequence consistent

### DIFF
--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -96,13 +96,13 @@ public extension Messages {
      *
      * - Returns: A subscription ``MessageSubscription`` that can be used to iterate through new messages.
      */
-    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscriptionAsyncSequence<SubscribeResponse.HistoryResult> {
+    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscriptionResponseAsyncSequence<SubscribeResponse.HistoryResult> {
         var emitEvent: ((ChatMessageEvent) -> Void)?
         let subscription = subscribe { event in
             emitEvent?(event)
         }
 
-        let subscriptionAsyncSequence = MessageSubscriptionAsyncSequence(
+        let subscriptionAsyncSequence = MessageSubscriptionResponseAsyncSequence(
             bufferingPolicy: bufferingPolicy,
             getPreviousMessages: subscription.historyBeforeSubscribe,
         )
@@ -120,7 +120,7 @@ public extension Messages {
     }
 
     /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
-    func subscribe() -> MessageSubscriptionAsyncSequence<SubscribeResponse.HistoryResult> {
+    func subscribe() -> MessageSubscriptionResponseAsyncSequence<SubscribeResponse.HistoryResult> {
         subscribe(bufferingPolicy: .unbounded)
     }
 }
@@ -355,8 +355,8 @@ public struct ChatMessageEvent: Sendable {
 
 /// A non-throwing `AsyncSequence` whose element is ``ChatMessageEvent``. The Chat SDK uses this type as the return value of the `AsyncSequence` convenience variants of the ``Messages`` methods that allow you to find out about received chat messages.
 ///
-/// You should only iterate over a given `MessageSubscriptionAsyncSequence` once; the results of iterating more than once are undefined.
-public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResult<Message>>: Sendable, AsyncSequence {
+/// You should only iterate over a given `MessageSubscriptionResponseAsyncSequence` once; the results of iterating more than once are undefined.
+public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: PaginatedResult<Message>>: Sendable, AsyncSequence {
     // swiftlint:disable:next missing_docs
     public typealias Element = ChatMessageEvent
 

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -104,7 +104,7 @@ public extension Messages {
 
         let subscriptionAsyncSequence = MessageSubscriptionResponseAsyncSequence(
             bufferingPolicy: bufferingPolicy,
-            getPreviousMessages: subscription.historyBeforeSubscribe,
+            historyBeforeSubscribe: subscription.historyBeforeSubscribe,
         )
         emitEvent = { [weak subscriptionAsyncSequence] event in
             subscriptionAsyncSequence?.emit(event)
@@ -363,22 +363,22 @@ public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: Pagin
     private let subscription: SubscriptionAsyncSequence<Element>
 
     // can be set by either initialiser
-    private let getPreviousMessages: @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult
+    private let historyBeforeSubscribe: @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult
 
     // used internally
     internal init(
         bufferingPolicy: BufferingPolicy,
-        getPreviousMessages: @escaping @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult,
+        historyBeforeSubscribe: @escaping @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult,
     ) {
         subscription = .init(bufferingPolicy: bufferingPolicy)
-        self.getPreviousMessages = getPreviousMessages
+        self.historyBeforeSubscribe = historyBeforeSubscribe
     }
 
     // used for testing
     // swiftlint:disable:next missing_docs
-    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockGetPreviousMessages: @escaping @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult) where Underlying.Element == Element {
+    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockHistoryBeforeSubscribe: @escaping @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult) where Underlying.Element == Element {
         subscription = .init(mockAsyncSequence: mockAsyncSequence)
-        getPreviousMessages = mockGetPreviousMessages
+        historyBeforeSubscribe = mockHistoryBeforeSubscribe
     }
 
     internal func emit(_ element: Element) {
@@ -391,8 +391,8 @@ public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: Pagin
     }
 
     // swiftlint:disable:next missing_docs
-    public func getPreviousMessages(withParams params: HistoryParams) async throws(ARTErrorInfo) -> HistoryResult {
-        try await getPreviousMessages(params)
+    public func historyBeforeSubscribe(withParams params: HistoryParams) async throws(ARTErrorInfo) -> HistoryResult {
+        try await historyBeforeSubscribe(params)
     }
 
     // swiftlint:disable:next missing_docs

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -232,7 +232,7 @@ struct DefaultMessagesTests {
         )
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(withParams: .init())
+        _ = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         // Then: subscription point is the current channelSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -259,7 +259,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHING
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(withParams: .init())
+        _ = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -286,7 +286,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(withParams: .init())
+        _ = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
@@ -301,7 +301,7 @@ struct DefaultMessagesTests {
             ARTChannelStateChange(current: .attached, previous: .detached, event: .attached, reason: nil, resumed: false),
         )
 
-        _ = try await subscription.getPreviousMessages(withParams: .init())
+        _ = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -328,7 +328,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(withParams: .init())
+        _ = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
@@ -340,7 +340,7 @@ struct DefaultMessagesTests {
             ARTChannelStateChange(current: .attached, previous: .attached, event: .update, reason: nil, resumed: false),
         )
 
-        _ = try await subscription.getPreviousMessages(withParams: .init())
+        _ = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -354,7 +354,7 @@ struct DefaultMessagesTests {
     // @spec CHA-M5h
     @available(iOS 16.0.0, tvOS 16.0.0, *) // To avoid "Runtime support for parameterized protocol types is only available in iOS 16.0.0 or newer" compile error
     @Test
-    func subscriptionGetPreviousMessagesAcceptsStandardHistoryQueryOptionsExceptForDirection() async throws {
+    func subscriptionhistoryBeforeSubscribeAcceptsStandardHistoryQueryOptionsExceptForDirection() async throws {
         // Given
         let realtime = MockRealtime {
             MockHTTPPaginatedResponse.successGetMessagesWithItems
@@ -368,7 +368,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
         let subscription = defaultMessages.subscribe()
-        let paginatedResult = try await subscription.getPreviousMessages(withParams: .init(orderBy: .oldestFirst)) // CHA-M5f, try to set unsupported direction
+        let paginatedResult = try await subscription.historyBeforeSubscribe(withParams: .init(orderBy: .oldestFirst)) // CHA-M5f, try to set unsupported direction
 
         let requestParams = try #require(realtime.requestArguments.first?.params)
 
@@ -391,7 +391,7 @@ struct DefaultMessagesTests {
 
     // @spec CHA-M5i
     @Test
-    func subscriptionGetPreviousMessagesThrowsErrorInfoInCaseOfServerError() async throws {
+    func subscriptionhistoryBeforeSubscribeThrowsErrorInfoInCaseOfServerError() async throws {
         // Given
         let artError = ARTErrorInfo.create(withCode: 50000, message: "Internal server error")
         let realtime = MockRealtime { @Sendable () throws(ARTErrorInfo) in
@@ -410,7 +410,7 @@ struct DefaultMessagesTests {
         // Then
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            _ = try await subscription.getPreviousMessages(withParams: .init())
+            _ = try await subscription.historyBeforeSubscribe(withParams: .init())
         }
         // Then
         await #expect {

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -221,7 +221,7 @@ struct IntegrationTests {
         /*
          TODO: This line should just be
 
-         let messages = try await rxMessageSubscription.getPreviousMessages(withParams: .init())
+         let messages = try await rxMessageSubscription.historyBeforeSubscribe(withParams: .init())
 
          but sometimes `messages.items` is coming back empty. Andy said in
          https://ably-real-time.slack.com/archives/C03JDBVM5MY/p1733220395208909
@@ -239,7 +239,7 @@ struct IntegrationTests {
          */
         let rxMessagesHistory = try await {
             while true {
-                let messages = try await rxMessageSubscription.getPreviousMessages(withParams: .init())
+                let messages = try await rxMessageSubscription.historyBeforeSubscribe(withParams: .init())
                 if !messages.items.isEmpty {
                     return messages
                 }

--- a/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
@@ -52,7 +52,7 @@ struct MessageSubscriptionResponseAsyncSequenceTests {
         let mockPaginatedResult = MockPaginatedResult<Message>()
         let subscription = MessageSubscriptionResponseAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
 
-        let result = try await subscription.getPreviousMessages(withParams: .init())
+        let result = try await subscription.historyBeforeSubscribe(withParams: .init())
         #expect(result === mockPaginatedResult)
     }
 }

--- a/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
@@ -25,7 +25,7 @@ private final class MockPaginatedResult<Item: Equatable>: PaginatedResult, @Main
     }
 }
 
-struct MessageSubscriptionAsyncSequenceTests {
+struct MessageSubscriptionResponseAsyncSequenceTests {
     let messages = ["First", "Second"].map { text in
         Message(serial: "", action: .create, clientID: "", text: text, metadata: [:], headers: [:], version: .init(serial: "", timestamp: Date()), timestamp: Date())
     }
@@ -33,13 +33,13 @@ struct MessageSubscriptionAsyncSequenceTests {
     @Test
     func withMockAsyncSequence() async {
         let events = messages.map { ChatMessageEvent(message: $0) }
-        let subscription = MessageSubscriptionAsyncSequence<MockPaginatedResult>(mockAsyncSequence: events.async) { _ in fatalError("Not implemented") }
+        let subscription = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(mockAsyncSequence: events.async) { _ in fatalError("Not implemented") }
         #expect(await Array(subscription.prefix(2)).map(\.message.text) == ["First", "Second"])
     }
 
     @Test
     func emit() async {
-        let subscription = MessageSubscriptionAsyncSequence<MockPaginatedResult>(bufferingPolicy: .unbounded) { _ in fatalError("Not implemented") }
+        let subscription = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(bufferingPolicy: .unbounded) { _ in fatalError("Not implemented") }
         async let emittedElements = Array(subscription.prefix(2))
         subscription.emit(ChatMessageEvent(message: messages[0]))
         subscription.emit(ChatMessageEvent(message: messages[1]))
@@ -50,7 +50,7 @@ struct MessageSubscriptionAsyncSequenceTests {
     @MainActor
     func mockGetPreviousMessages() async throws {
         let mockPaginatedResult = MockPaginatedResult<Message>()
-        let subscription = MessageSubscriptionAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
+        let subscription = MessageSubscriptionResponseAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
 
         let result = try await subscription.getPreviousMessages(withParams: .init())
         #expect(result === mockPaginatedResult)


### PR DESCRIPTION
Re-doing #381 after accidentally merging too soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed public type MessageSubscriptionAsyncSequence → MessageSubscriptionResponseAsyncSequence.
  - subscribe() and subscribe(bufferingPolicy:) now return MessageSubscriptionResponseAsyncSequence.
  - getPreviousMessages(withParams:) renamed to historyBeforeSubscribe(withParams:).
  - Room protocol made generic: Room → Room<Channel> (exposes a Channel type parameter).

- Documentation
  - Public docs updated to reflect renamed types and methods.

- Tests
  - Test suites updated and renamed to use the new APIs and types; added tests exercising Room<ARTRealtimeChannel> existentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->