### PR TITLE
refactor: use JSONObject alias for metadata

### DIFF
--- a/Sources/AblyChat/Metadata.swift
+++ b/Sources/AblyChat/Metadata.swift
@@ -8,4 +8,4 @@
  * Do not use metadata for authoritative information. There is no server-side
  * validation. When reading the metadata treat it like user input.
  */
-public typealias Metadata = [String: JSONValue]
+public typealias Metadata = JSONObject


### PR DESCRIPTION
We have a type alias now, so using it here for consistency!